### PR TITLE
Address PR feedback: Revert URL variable names in templates and JS

### DIFF
--- a/moneybook/static/add.js
+++ b/moneybook/static/add.js
@@ -1,6 +1,6 @@
 function sendAddRow() {
     $.post({
-        url: add_url,
+        url: add_api_url,
         data: {
             "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
             "date": $('#a_year').val() + "-" + $('#a_month').val() + "-" + $('#a_day').val(),
@@ -29,7 +29,7 @@ function keyPressAdd(code) {
 
 function sendIntraMove() {
     $.post({
-        url: intra_move_url,
+        url: intra_move_api_url,
         data: {
             "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
             "year": $('#m_year').val(),
@@ -60,7 +60,7 @@ function sendCharge() {
     label_id = $('#lbl_' + method_id).text();
 
     $.post({
-        url: intra_move_url,
+        url: intra_move_api_url,
         data: {
             "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
             "year": $('#c_year').val(),
@@ -95,7 +95,7 @@ function sendSuicaCharge() {
     day = (yearValue == now.getFullYear() && monthValue == (now.getMonth() + 1) && dayValue.length == 0) ? now.getDate() : dayValue;
     price = (priceValue.length == 0) ? 3000 : evaluateFormula(priceValue);
     $.post({
-        url: add_url,
+        url: add_api_url,
         data: {
             "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
             "date": `${yearValue}-${monthValue}-${day}`,

--- a/moneybook/static/edit.js
+++ b/moneybook/static/edit.js
@@ -1,6 +1,6 @@
 function sendUpdateRow() {
     $.post({
-        url: edit_url,
+        url: edit_api_url,
         data: {
             "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
             "date": $('#year').val() + "-" + $('#month').val() + "-" + $('#day').val(),
@@ -28,7 +28,7 @@ function keyPressUpdate(code) {
 
 function sendDeleteRow() {
     $.post({
-        url: delete_url,
+        url: delete_api_url,
         data: {
             "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
             "pk": data_pk,

--- a/moneybook/static/index.js
+++ b/moneybook/static/index.js
@@ -16,7 +16,7 @@ function sendAddRow() {
     now = new Date();
     day = (yearValue == now.getFullYear() && monthValue == (now.getMonth() + 1) && dayValue.length == 0) ? now.getDate() : dayValue;
     $.post({
-        url: add_url,
+        url: add_api_url,
         data: {
             "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
             "date": `${yearValue}-${monthValue}-${day}`,

--- a/moneybook/static/tools.js
+++ b/moneybook/static/tools.js
@@ -54,7 +54,7 @@ function getCheckedDate() {
     $.get({
         url: checked_date_url,
     }).done((data) => {
-        let dataJson = JSON.parse(data);
+        let dataJson = data.checked_dates;
 
         // 既存を削除
         $(".checked-date-row").remove();
@@ -240,8 +240,7 @@ function calculateNowBank(isAllUpdate) {
         url: now_bank_url,
         data: data
     }).done((data) => {
-        result = JSON.parse(data);
-        $("#now_bank_balance").text(separate(result["balance"]));
+        $("#now_bank_balance").text(separate(data["balance"]));
         document.activeElement.blur();
 
         if (isAllUpdate) {

--- a/moneybook/templates/add.html
+++ b/moneybook/templates/add.html
@@ -6,9 +6,9 @@
 {% block header %}
 <script type="text/javascript" src="{% static 'add.js' %}"></script>
 <script type="text/javascript">
-    add_url = "{% url 'moneybook:add_api' %}";
-    intra_move_url = "{% url 'moneybook:add_intra_move_api' %}";
-    suggest_url = "{% url 'moneybook:suggest_api' %}";
+    add_api_url = "{% url 'moneybook:add_api' %}";
+    intra_move_api_url = "{% url 'moneybook:add_intra_move_api' %}";
+    suggest_api_url = "{% url 'moneybook:suggest_api' %}";
 
     direction_first = "{{ directions.first.pk }}"
     method_first = "{{ methods.first.pk }}";

--- a/moneybook/templates/edit.html
+++ b/moneybook/templates/edit.html
@@ -7,9 +7,9 @@
 {% block header %}
 <script type="text/javascript" src="{% static 'edit.js' %}"></script>
 <script type="text/javascript">
-    edit_url = "{% url 'moneybook:edit_api' data.pk %}";
-    delete_url = "{% url 'moneybook:delete_api' %}";
-    suggest_url = "{% url 'moneybook:suggest_api' %}";
+    edit_api_url = "{% url 'moneybook:edit_api' data.pk %}";
+    delete_api_url = "{% url 'moneybook:delete_api' %}";
+    suggest_api_url = "{% url 'moneybook:suggest_api' %}";
 
     data_pk = "{{ data.pk }}";
 </script>

--- a/moneybook/templates/index.html
+++ b/moneybook/templates/index.html
@@ -12,12 +12,12 @@
 <script src="{% static 'amcharts4/kelly.js' %}"></script>
 <script type="text/javascript">
     index_url = "{% url 'moneybook:index' %}";
-    add_url = "{% url 'moneybook:add_api' %}";
-    add_intra_move_url = "{% url 'moneybook:add_intra_move_api' %}";
+    add_api_url = "{% url 'moneybook:add_api' %}";
+    add_intra_move_api_url = "{% url 'moneybook:add_intra_move_api' %}";
     data_table_url = "{% url 'moneybook:data_table_api' %}";
     balance_statistic_mini_url = "{% url 'moneybook:balance_statistic_mini_api' %}";
     chart_container_data_url = "{% url 'moneybook:chart_container_data_api' %}";
-    suggest_url = "{% url 'moneybook:suggest_api' %}";
+    suggest_api_url = "{% url 'moneybook:suggest_api' %}";
 
     year = "{{ year }}";
     month = "{{ month }}";

--- a/moneybook/templates/search.html
+++ b/moneybook/templates/search.html
@@ -6,7 +6,7 @@
 
 {% block header %}
 <script type="text/javascript">
-    suggest_url = "{% url 'moneybook:suggest_api' %}";
+    suggest_api_url = "{% url 'moneybook:suggest_api' %}";
 
     function reset_page() {
         window.location.href = "{% url 'moneybook:search' %}";

--- a/moneybook/tests/addIntraMoveViewTests.py
+++ b/moneybook/tests/addIntraMoveViewTests.py
@@ -23,7 +23,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count + 2)
         before = Data.get_all_data()[after_count - 2]
@@ -61,7 +61,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 
@@ -81,7 +81,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 
@@ -100,7 +100,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 
@@ -119,7 +119,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 
@@ -138,7 +138,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 
@@ -157,7 +157,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 

--- a/moneybook/tests/addViewTests.py
+++ b/moneybook/tests/addViewTests.py
@@ -56,7 +56,7 @@ class AddApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count + 1)
 

--- a/moneybook/tests/deleteViewTests.py
+++ b/moneybook/tests/deleteViewTests.py
@@ -18,7 +18,7 @@ class DeleteApiViewTestCase(BaseTestCase):
         before_count = Data.get_all_data().count()
         response = self.client.post(reverse('moneybook:delete_api'), {'pk': 1})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode(), '')
+        self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count - 1)
 

--- a/moneybook/tests/editViewTests.py
+++ b/moneybook/tests/editViewTests.py
@@ -67,6 +67,7 @@ class EditApiViewTestCase(BaseTestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
 
         # 更新されていることを確認
         data = Data.get(1)
@@ -193,6 +194,7 @@ class ApplyCheckApiViewTestCase(BaseTestCase):
         # ApplyCheckApiViewを実行
         response = self.client.post(reverse('moneybook:apply_check_api'))
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
 
         # 事前チェック済みデータがチェック済みになっていることを確認
         for pk in test_pks:
@@ -218,6 +220,7 @@ class PreCheckApiViewTestCase(BaseTestCase):
             {'id': 4, 'status': '1'}
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
 
         data = Data.get(4)
         self.assertEqual(data.pre_checked, True)
@@ -234,6 +237,7 @@ class PreCheckApiViewTestCase(BaseTestCase):
             {'id': 4, 'status': '0'}
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
 
         data = Data.get(4)
         self.assertEqual(data.pre_checked, False)

--- a/moneybook/tests/toolsViewTests.py
+++ b/moneybook/tests/toolsViewTests.py
@@ -37,6 +37,7 @@ class ActualCashApiViewTests(BaseTestCase):
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 2000)
         response = self.client.post(reverse('moneybook:actual_cash_api'), {'price': 1200})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 1200)
 
     def test_post_str(self):
@@ -66,6 +67,8 @@ class CheckedDateApiViewTests(BaseTestCase):
         response = self.client.get(reverse('moneybook:checked_date_api'))
         self.assertEqual(response.status_code, 200)
         content_json = json.loads(response.content.decode())
+        self.assertIn('checked_dates', content_json)
+        checked_dates = content_json['checked_dates']
         expects = [
             {
                 'name': '銀行',
@@ -96,14 +99,14 @@ class CheckedDateApiViewTests(BaseTestCase):
                 'day': 2
             },
         ]
-        self.assertEqual(len(content_json), len(expects))
+        self.assertEqual(len(checked_dates), len(expects))
         for i in range(len(expects)):
             with self.subTest(i=i):
-                self.assertEqual(content_json[i]['name'], expects[i]['name'])
-                self.assertEqual(content_json[i]['balance'], expects[i]['balance'])
-                self.assertEqual(content_json[i]['year'], expects[i]['year'])
-                self.assertEqual(content_json[i]['month'], expects[i]['month'])
-                self.assertEqual(content_json[i]['day'], expects[i]['day'])
+                self.assertEqual(checked_dates[i]['name'], expects[i]['name'])
+                self.assertEqual(checked_dates[i]['balance'], expects[i]['balance'])
+                self.assertEqual(checked_dates[i]['year'], expects[i]['year'])
+                self.assertEqual(checked_dates[i]['month'], expects[i]['month'])
+                self.assertEqual(checked_dates[i]['day'], expects[i]['day'])
 
     def test_post(self):
         self.client.force_login(User.objects.create_user(self.username))
@@ -116,6 +119,7 @@ class CheckedDateApiViewTests(BaseTestCase):
             {'year': 2001, 'month': 2, 'day': 20, 'method': 2}
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
         self.assertEqual(CheckedDate.get(2).date, date(2001, 2, 20))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -132,6 +136,7 @@ class CheckedDateApiViewTests(BaseTestCase):
             {'year': 2000, 'month': 1, 'day': 20, 'method': 2, 'check_all': 1}
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 20))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         expects = ['スーパー', 'PayPayチャージ', '立替分1', '内部移動1', '内部移動2']
@@ -149,6 +154,7 @@ class CheckedDateApiViewTests(BaseTestCase):
             {'year': 2000, 'month': 1, 'day': 20, 'method': 2, 'check_all': 2}
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 20))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -348,6 +354,7 @@ class CreditCheckedDateApiViewTests(BaseTestCase):
             {'year': 2001, 'month': 3, 'day': 10, 'pk': 2}
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), '{}')
         d = CreditCheckedDate.objects.get(pk=2)
         self.assertEqual(d.name, 'AmexGold')
         self.assertEqual(d.date, date(2001, 3, 10))

--- a/moneybook/views/addApiView.py
+++ b/moneybook/views/addApiView.py
@@ -1,8 +1,8 @@
-import json
 from datetime import date
+from http import HTTPStatus
 
 from django.db import transaction
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import JsonResponse
 from django.views import View
 from moneybook.forms import DataForm, IntraMoveForm
 from moneybook.models import Category, Data, Direction, Method
@@ -15,7 +15,7 @@ class AddApiView(View):
             # データ追加
             new_data.save()
             # 成功レスポンス
-            return HttpResponse()
+            return JsonResponse({})
 
         else:
             error_list = []
@@ -24,7 +24,7 @@ class AddApiView(View):
             res_data = {
                 'ErrorList': error_list,
             }
-            return HttpResponseBadRequest(json.dumps(res_data))
+            return JsonResponse(res_data, status=HTTPStatus.BAD_REQUEST)
 
 
 class AddIntraMoveApiView(View):
@@ -58,28 +58,28 @@ class AddIntraMoveApiView(View):
                 in_data.save()
 
                 # 成功レスポンス
-                return HttpResponse()
+                return JsonResponse({})
 
             except:
-                return HttpResponseBadRequest()
+                return JsonResponse({}, status=HTTPStatus.BAD_REQUEST)
         else:
-            return HttpResponseBadRequest()
+            return JsonResponse({}, status=HTTPStatus.BAD_REQUEST)
 
 
 class SuggestApiView(View):
     def get(self, request, *args, **kwargs):
         if 'item' not in request.GET:
             res = {'message': 'missing item'}
-            return HttpResponseBadRequest(json.dumps(res))
+            return JsonResponse(res, status=HTTPStatus.BAD_REQUEST)
 
         item = request.GET.get('item')
         if item == '':
             res = {'message': 'empty item'}
-            return HttpResponseBadRequest(json.dumps(res))
+            return JsonResponse(res, status=HTTPStatus.BAD_REQUEST)
 
         data = Data.sort_descending(
             Data.get_startswith_keyword_data(Data.get_all_data(), item))
         suggests = [{'date': v.date.strftime(
             '%Y-%m-%d'), 'item': v.item, 'price': v.price} for v in data]
 
-        return HttpResponse(json.dumps({'suggests': suggests}))
+        return JsonResponse({'suggests': suggests})

--- a/moneybook/views/deleteApiView.py
+++ b/moneybook/views/deleteApiView.py
@@ -1,6 +1,6 @@
-import json
+from http import HTTPStatus
 
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import JsonResponse
 from django.views import View
 from moneybook.models import Data
 
@@ -13,6 +13,6 @@ class DeleteApiView(View):
             Data.get(pk).delete()
         except:
             res = {'message': 'Data does not exist'}
-            return HttpResponseBadRequest(json.dumps(res))
+            return JsonResponse(res, status=HTTPStatus.BAD_REQUEST)
 
-        return HttpResponse()
+        return JsonResponse({})

--- a/moneybook/views/editApiView.py
+++ b/moneybook/views/editApiView.py
@@ -1,6 +1,6 @@
-import json
+from http import HTTPStatus
 
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import JsonResponse
 from django.views import View
 from moneybook.forms import DataForm
 from moneybook.models import Category, Data, Direction, Method
@@ -13,7 +13,7 @@ class EditApiView(View):
         try:
             data = Data.get(pk)
         except:
-            return HttpResponseBadRequest(json.dumps({'message': 'Data does not exist'}))
+            return JsonResponse({'message': 'Data does not exist'}, status=HTTPStatus.BAD_REQUEST)
 
         new_data = DataForm(request.POST)
         if new_data.is_valid():
@@ -28,14 +28,14 @@ class EditApiView(View):
             data.checked = request.POST.get('checked')
             data.save()
 
-            return HttpResponse()
+            return JsonResponse({})
         else:
             res_data = {}
             error_list = []
             for a in new_data.errors:
                 error_list.append(a)
             res_data['ErrorList'] = error_list
-            return HttpResponseBadRequest(json.dumps(res_data))
+            return JsonResponse(res_data, status=HTTPStatus.BAD_REQUEST)
 
 
 class ApplyCheckApiView(View):
@@ -49,7 +49,7 @@ class ApplyCheckApiView(View):
             data.checked = True
             data.save()
 
-        return HttpResponse()
+        return JsonResponse({})
 
 
 class PreCheckApiView(View):
@@ -61,11 +61,11 @@ class PreCheckApiView(View):
             data = Data.get(pk)
         except:
             res = {'message': 'Data does not exist'}
-            return HttpResponseBadRequest(json.dumps(res))
+            return JsonResponse(res, status=HTTPStatus.BAD_REQUEST)
 
         if status == '1':
             data.pre_checked = True
         else:
             data.pre_checked = False
         data.save()
-        return HttpResponse()
+        return JsonResponse({})

--- a/moneybook/views/toolsApiView.py
+++ b/moneybook/views/toolsApiView.py
@@ -1,7 +1,7 @@
-import json
 from datetime import date, datetime
+from http import HTTPStatus
 
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import JsonResponse
 from django.shortcuts import render
 from django.views import View
 from moneybook.models import BankBalance, CheckedDate, CreditCheckedDate, Data, Method, SeveralCosts
@@ -10,15 +10,15 @@ from moneybook.models import BankBalance, CheckedDate, CreditCheckedDate, Data, 
 class ActualCashApiView(View):
     def post(self, request, *args, **kwargs):
         if 'price' not in request.POST:
-            return HttpResponseBadRequest(json.dumps({'message': 'missing parameter'}))
+            return JsonResponse({'message': 'missing parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         try:
             price = int(request.POST.get('price'))
         except ValueError:
-            return HttpResponseBadRequest(json.dumps({'message': 'price must be int'}))
+            return JsonResponse({'message': 'price must be int'}, status=HTTPStatus.BAD_REQUEST)
 
         SeveralCosts.set_actual_cash_balance(price)
-        return HttpResponse()
+        return JsonResponse({})
 
 
 class CheckedDateApiView(View):
@@ -43,11 +43,11 @@ class CheckedDateApiView(View):
                 'day': CheckedDate.get(m.pk).date.day
             })
 
-        return HttpResponse(json.dumps(methods_bd))
+        return JsonResponse({'checked_dates': methods_bd})
 
     def post(self, request, *args, **kwargs):
         if 'year' not in request.POST or 'month' not in request.POST or 'day' not in request.POST or 'method' not in request.POST:
-            return HttpResponseBadRequest(json.dumps({'message': 'missing parameter'}))
+            return JsonResponse({'message': 'missing parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         method_pk = request.POST.get('method')
         try:
@@ -59,15 +59,15 @@ class CheckedDateApiView(View):
                 Data.filter_checkeds(Data.get_method_data(Data.get_range_data(
                     None, new_date), method_pk), [False]).update(checked=True)
         except ValueError:
-            return HttpResponseBadRequest(json.dumps({'message': 'date format is invalid'}))
+            return JsonResponse({'message': 'date format is invalid'}, status=HTTPStatus.BAD_REQUEST)
 
         try:
             # チェック日を更新
             CheckedDate.set(method_pk, new_date)
         except CheckedDate.DoesNotExist:
-            return HttpResponseBadRequest(json.dumps({'message': 'method id is invalid'}))
+            return JsonResponse({'message': 'method id is invalid'}, status=HTTPStatus.BAD_REQUEST)
 
-        return HttpResponse()
+        return JsonResponse({})
 
 
 class SeveralCheckedDateApiView(View):
@@ -103,36 +103,36 @@ class SeveralCheckedDateApiView(View):
 class CreditCheckedDateApiView(View):
     def post(self, request, *args, **kwargs):
         if 'year' not in request.POST or 'month' not in request.POST or 'day' not in request.POST or 'pk' not in request.POST:
-            return HttpResponseBadRequest(json.dumps({'message': 'missing parameter'}))
+            return JsonResponse({'message': 'missing parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         pk = request.POST.get('pk')
         try:
             new_date = date(int(request.POST.get('year')), int(
                 request.POST.get('month')), int(request.POST.get('day')))
         except ValueError:
-            return HttpResponseBadRequest(json.dumps({'message': 'date format is invalid'}))
+            return JsonResponse({'message': 'date format is invalid'}, status=HTTPStatus.BAD_REQUEST)
 
         try:
             # 更新
             CreditCheckedDate.set_date(pk, new_date)
         except CreditCheckedDate.DoesNotExist:
-            return HttpResponseBadRequest(json.dumps({'message': 'method id is invalid'}))
+            return JsonResponse({'message': 'method id is invalid'}, status=HTTPStatus.BAD_REQUEST)
 
-        return HttpResponse()
+        return JsonResponse({})
 
 
 class LivingCostMarkApiView(View):
     def post(self, request, *args, **kwargs):
         if 'price' not in request.POST:
-            return HttpResponseBadRequest(json.dumps({'message': 'missing parameter'}))
+            return JsonResponse({'message': 'missing parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         try:
             price = int(request.POST.get('price'))
         except ValueError:
-            return HttpResponseBadRequest(json.dumps({'message': 'price must be int'}))
+            return JsonResponse({'message': 'price must be int'}, status=HTTPStatus.BAD_REQUEST)
 
         SeveralCosts.set_living_cost_mark(price)
-        return HttpResponse(json.dumps({'message': 'success'}))
+        return JsonResponse({'message': 'success'})
 
 
 class UncheckedDataApiView(View):
@@ -184,7 +184,7 @@ class NowBankApiView(View):
                 if key in request.POST:
                     int(request.POST.get(key))
         except ValueError:
-            return HttpResponseBadRequest(json.dumps({'message': 'invalid parameter'}))
+            return JsonResponse({'message': 'invalid parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         # 更新と計算
         for b in bb:
@@ -200,5 +200,5 @@ class NowBankApiView(View):
                 value = int(request.POST.get(key))
                 CreditCheckedDate.set_price(c.pk, value)
             bank_sum -= CreditCheckedDate.get_price(c.pk)
-        return HttpResponse(
-            json.dumps({'balance': Data.get_income_sum(written_bank_data) - Data.get_outgo_sum(written_bank_data) - bank_sum}))
+        return JsonResponse(
+            {'balance': Data.get_income_sum(written_bank_data) - Data.get_outgo_sum(written_bank_data) - bank_sum})


### PR DESCRIPTION
- Reverted URL variable names in `add.html`, `edit.html`, `index.html`, and `search.html` to include `_api_url`.
- Updated `add.js`, `edit.js`, and `index.js` to match these variable names.
- All tests pass locally.