### PR TITLE
Add "Train Fare" shortcut to add page

### DIFF
--- a/moneybook/e2e/add.py
+++ b/moneybook/e2e/add.py
@@ -467,6 +467,68 @@ class Add(SeleniumBase):
         tds[5].find_element(By.TAG_NAME, 'a').click()
         self.assertEqual(self.driver.find_element(By.XPATH, '//form/table[1]/tbody/tr[4]/td[1]/input[2]').is_selected(), True)
 
+    def test_train_fare_shortcut_default_day(self):
+        now = datetime.now()
+        # 前処理
+        self._login()
+        self._location(self.live_server_url + reverse('moneybook:add'))
+
+        # テスト - 日付を空にして送信
+        self.driver.find_element(By.ID, 's_price').send_keys('600')
+        self.driver.find_element(By.XPATH, '//form[3]/table/tbody/tr[3]/td/input[@type="button"][2]').click()
+
+        self._location(self.live_server_url + reverse('moneybook:index'))
+        rows = self.driver.find_elements(By.XPATH, '//*[@id="transactions"]/table/tbody/tr')
+        self.assertEqual(len(rows), 2)
+        tds = rows[1].find_elements(By.TAG_NAME, 'td')
+        # 今日の日付が使われていることを確認
+        self.assertEqual(tds[0].text, str(now.year) + '/' + str.zfill(str(now.month), 2) + '/' + str.zfill(str(now.day), 2))
+        self.assertEqual(tds[1].text, '電車代')
+        self.assertEqual(tds[2].text, '600')
+        self.assertEqual(tds[3].text, '銀行')
+        self.assertEqual(tds[4].text, '交通費')
+
+    def test_train_fare_shortcut_default_price(self):
+        now = datetime.now()
+        # 前処理
+        self._login()
+        self._location(self.live_server_url + reverse('moneybook:add'))
+
+        # テスト - 金額を空にして送信
+        self.driver.find_element(By.ID, 's_day').send_keys('7')
+        self.driver.find_element(By.XPATH, '//form[3]/table/tbody/tr[3]/td/input[@type="button"][2]').click()
+
+        self._location(self.live_server_url + reverse('moneybook:index'))
+        rows = self.driver.find_elements(By.XPATH, '//*[@id="transactions"]/table/tbody/tr')
+        self.assertEqual(len(rows), 2)
+        tds = rows[1].find_elements(By.TAG_NAME, 'td')
+        self.assertEqual(tds[0].text, str(now.year) + '/' + str.zfill(str(now.month), 2) + '/' + '07')
+        self.assertEqual(tds[1].text, '電車代')
+        # デフォルトの3000円が使われていることを確認
+        self.assertEqual(tds[2].text, '3,000')
+        self.assertEqual(tds[3].text, '銀行')
+        self.assertEqual(tds[4].text, '交通費')
+
+    def test_train_fare_shortcut_all_defaults(self):
+        now = datetime.now()
+        # 前処理
+        self._login()
+        self._location(self.live_server_url + reverse('moneybook:add'))
+
+        # テスト - 日付も金額も空で送信
+        self.driver.find_element(By.XPATH, '//form[3]/table/tbody/tr[3]/td/input[@type="button"][2]').click()
+
+        self._location(self.live_server_url + reverse('moneybook:index'))
+        rows = self.driver.find_elements(By.XPATH, '//*[@id="transactions"]/table/tbody/tr')
+        self.assertEqual(len(rows), 2)
+        tds = rows[1].find_elements(By.TAG_NAME, 'td')
+        # 今日の日付とデフォルトの3000円が使われていることを確認
+        self.assertEqual(tds[0].text, str(now.year) + '/' + str.zfill(str(now.month), 2) + '/' + str.zfill(str(now.day), 2))
+        self.assertEqual(tds[1].text, '電車代')
+        self.assertEqual(tds[2].text, '3,000')
+        self.assertEqual(tds[3].text, '銀行')
+        self.assertEqual(tds[4].text, '交通費')
+
     def test_manual_add_click(self):
         now = datetime.now()
         # 前処理

--- a/moneybook/e2e/add.py
+++ b/moneybook/e2e/add.py
@@ -443,6 +443,30 @@ class Add(SeleniumBase):
         self.assertEqual(tds[3].text, '銀行')
         self.assertEqual(tds[4].text, '交通費')
 
+    def test_train_fare_shortcut(self):
+        now = datetime.now()
+        # 前処理
+        self._login()
+        self._location(self.live_server_url + reverse('moneybook:add'))
+
+        # テスト
+        self.driver.find_element(By.ID, 's_day').send_keys('6')
+        self.driver.find_element(By.ID, 's_price').send_keys('600')
+        self.driver.find_element(By.XPATH, '//form[3]/table/tbody/tr[3]/td/input[@type="button"][2]').click()
+
+        self._location(self.live_server_url + reverse('moneybook:index'))
+        rows = self.driver.find_elements(By.XPATH, '//*[@id="transactions"]/table/tbody/tr')
+        self.assertEqual(len(rows), 2)
+        tds = rows[1].find_elements(By.TAG_NAME, 'td')
+        self.assertEqual(tds[0].text, str(now.year) + '/' + str.zfill(str(now.month), 2) + '/' + '06')
+        self.assertEqual(tds[1].text, '電車代')
+        self.assertEqual(tds[2].text, '600')
+        self.assertEqual(tds[3].text, '銀行')
+        self.assertEqual(tds[4].text, '交通費')
+        # direction確認
+        tds[5].find_element(By.TAG_NAME, 'a').click()
+        self.assertEqual(self.driver.find_element(By.XPATH, '//form/table[1]/tbody/tr[4]/td[1]/input[2]').is_selected(), True)
+
     def test_manual_add_click(self):
         now = datetime.now()
         # 前処理

--- a/moneybook/static/add.js
+++ b/moneybook/static/add.js
@@ -86,7 +86,7 @@ function keyPressCharge(code) {
     }
 }
 
-function sendSuicaCharge() {
+function sendTrafficCostShortcut(item) {
     yearValue = $('#s_year').val();
     monthValue = $('#s_month').val();
     dayValue = $('#s_day').val();
@@ -99,37 +99,7 @@ function sendSuicaCharge() {
         data: {
             "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
             "date": `${yearValue}-${monthValue}-${day}`,
-            "item": "Suicaチャージ",
-            "price": price,
-            "direction": 2,
-            "method": bank_pk,
-            "category": traffic_cost_pk,
-            "temp": "False",
-            "checked": "False",
-        }
-    }).done(() => {
-        resetForShortcut();
-        showResultMsg("Success!", empty);
-    }).fail(() => {
-        // メッセージ表示
-        showResultMsg("Error...", empty);
-    });
-}
-
-function sendTrainFare() {
-    yearValue = $('#s_year').val();
-    monthValue = $('#s_month').val();
-    dayValue = $('#s_day').val();
-    priceValue = $('#s_price').val();
-    now = new Date();
-    day = (yearValue == now.getFullYear() && monthValue == (now.getMonth() + 1) && dayValue.length == 0) ? now.getDate() : dayValue;
-    price = (priceValue.length == 0) ? 3000 : evaluateFormula(priceValue);
-    $.post({
-        url: add_api_url,
-        data: {
-            "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
-            "date": `${yearValue}-${monthValue}-${day}`,
-            "item": "電車代",
+            "item": item,
             "price": price,
             "direction": 2,
             "method": bank_pk,

--- a/moneybook/static/add.js
+++ b/moneybook/static/add.js
@@ -116,6 +116,36 @@ function sendSuicaCharge() {
     });
 }
 
+function sendTrainFare() {
+    yearValue = $('#s_year').val();
+    monthValue = $('#s_month').val();
+    dayValue = $('#s_day').val();
+    priceValue = $('#s_price').val();
+    now = new Date();
+    day = (yearValue == now.getFullYear() && monthValue == (now.getMonth() + 1) && dayValue.length == 0) ? now.getDate() : dayValue;
+    price = (priceValue.length == 0) ? 3000 : evaluateFormula(priceValue);
+    $.post({
+        url: add_api_url,
+        data: {
+            "csrfmiddlewaretoken": $('input[name="csrfmiddlewaretoken"]').val(),
+            "date": `${yearValue}-${monthValue}-${day}`,
+            "item": "電車代",
+            "price": price,
+            "direction": 2,
+            "method": bank_pk,
+            "category": traffic_cost_pk,
+            "temp": "False",
+            "checked": "False",
+        }
+    }).done(() => {
+        resetForShortcut();
+        showResultMsg("Success!", empty);
+    }).fail(() => {
+        // メッセージ表示
+        showResultMsg("Error...", empty);
+    });
+}
+
 function resetAddForm() {
     // フォームをリセット
     // チャージ

--- a/moneybook/templates/add.html
+++ b/moneybook/templates/add.html
@@ -122,8 +122,8 @@
             <tr>
                 <th>項目</th>
                 <td>
-                    <input type="button" class="btn-green" onclick="sendSuicaCharge()" value="Suicaチャージ">
-                    <input type="button" class="btn-green" onclick="sendTrainFare()" value="電車代">
+                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('Suicaチャージ')" value="Suicaチャージ">
+                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('電車代')" value="電車代">
                 </td>
             </tr>
         </table>

--- a/moneybook/templates/add.html
+++ b/moneybook/templates/add.html
@@ -123,6 +123,7 @@
                 <th>項目</th>
                 <td>
                     <input type="button" class="btn-green" onclick="sendSuicaCharge()" value="Suicaチャージ">
+                    <input type="button" class="btn-green" onclick="sendTrainFare()" value="電車代">
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
Added a new shortcut button "電車代" (Train Fare) to the transaction addition page. This shortcut uses the same parameters as the "Suicaチャージ" (Suica Charge) shortcut, defaulting to a Bank payment method and a Traffic Cost category. The implementation includes the HTML button, the JavaScript handler for the AJAX request, and a Selenium E2E test to ensure correct functionality.

---
*PR created automatically by Jules for task [12159834563403882303](https://jules.google.com/task/12159834563403882303) started by @tMorriss*