### PR TITLE
Add merge_queue support to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@
 
 name: ci
 
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   lint:


### PR DESCRIPTION
Added `merge_group` to the `on` section of `.github/workflows/ci.yml` to support GitHub Merge Queue. This ensures that CI checks are executed for merge groups, maintaining the same level of verification as pull requests.

---
*PR created automatically by Jules for task [6073136338732654058](https://jules.google.com/task/6073136338732654058) started by @tMorriss*