### PR TITLE
Suicaチャージショートカットのデフォルト金額を1000円に変更

### DIFF
--- a/moneybook/e2e/add.py
+++ b/moneybook/e2e/add.py
@@ -98,7 +98,7 @@ class Add(SeleniumBase):
         self.assertEqual(self.driver.find_element(By.ID, 's_day').get_attribute('value'), '')
         self.assertEqual(self.driver.find_element(By.ID, 's_day').get_attribute('placeholder'), str(now.day))
         self.assertEqual(self.driver.find_element(By.ID, 's_price').get_attribute('value'), '')
-        self.assertEqual(self.driver.find_element(By.ID, 's_price').get_attribute('placeholder'), '3000')
+        self.assertEqual(self.driver.find_element(By.ID, 's_price').get_attribute('placeholder'), '1000')
         self.assertEqual(self.driver.find_element(By.XPATH,
                                                   '//section/form[3]/table/tbody/tr[3]/td/input[1]').get_attribute('value'), 'Suicaチャージ')
 
@@ -418,8 +418,8 @@ class Add(SeleniumBase):
         tds = rows[1].find_elements(By.TAG_NAME, 'td')
         self.assertEqual(tds[0].text, str(now.year) + '/' + str.zfill(str(now.month), 2) + '/' + '05')
         self.assertEqual(tds[1].text, 'Suicaチャージ')
-        # デフォルトの3000円が使われていることを確認
-        self.assertEqual(tds[2].text, '3,000')
+        # デフォルトの1000円が使われていることを確認
+        self.assertEqual(tds[2].text, '1,000')
         self.assertEqual(tds[3].text, '銀行')
         self.assertEqual(tds[4].text, '交通費')
 
@@ -436,10 +436,10 @@ class Add(SeleniumBase):
         rows = self.driver.find_elements(By.XPATH, '//*[@id="transactions"]/table/tbody/tr')
         self.assertEqual(len(rows), 2)
         tds = rows[1].find_elements(By.TAG_NAME, 'td')
-        # 今日の日付とデフォルトの3000円が使われていることを確認
+        # 今日の日付とデフォルトの1000円が使われていることを確認
         self.assertEqual(tds[0].text, str(now.year) + '/' + str.zfill(str(now.month), 2) + '/' + str.zfill(str(now.day), 2))
         self.assertEqual(tds[1].text, 'Suicaチャージ')
-        self.assertEqual(tds[2].text, '3,000')
+        self.assertEqual(tds[2].text, '1,000')
         self.assertEqual(tds[3].text, '銀行')
         self.assertEqual(tds[4].text, '交通費')
 
@@ -504,8 +504,8 @@ class Add(SeleniumBase):
         tds = rows[1].find_elements(By.TAG_NAME, 'td')
         self.assertEqual(tds[0].text, str(now.year) + '/' + str.zfill(str(now.month), 2) + '/' + '07')
         self.assertEqual(tds[1].text, '電車代')
-        # デフォルトの3000円が使われていることを確認
-        self.assertEqual(tds[2].text, '3,000')
+        # デフォルトの1000円が使われていることを確認
+        self.assertEqual(tds[2].text, '1,000')
         self.assertEqual(tds[3].text, '銀行')
         self.assertEqual(tds[4].text, '交通費')
 
@@ -522,10 +522,10 @@ class Add(SeleniumBase):
         rows = self.driver.find_elements(By.XPATH, '//*[@id="transactions"]/table/tbody/tr')
         self.assertEqual(len(rows), 2)
         tds = rows[1].find_elements(By.TAG_NAME, 'td')
-        # 今日の日付とデフォルトの3000円が使われていることを確認
+        # 今日の日付とデフォルトの1000円が使われていることを確認
         self.assertEqual(tds[0].text, str(now.year) + '/' + str.zfill(str(now.month), 2) + '/' + str.zfill(str(now.day), 2))
         self.assertEqual(tds[1].text, '電車代')
-        self.assertEqual(tds[2].text, '3,000')
+        self.assertEqual(tds[2].text, '1,000')
         self.assertEqual(tds[3].text, '銀行')
         self.assertEqual(tds[4].text, '交通費')
 

--- a/moneybook/static/add.js
+++ b/moneybook/static/add.js
@@ -86,14 +86,14 @@ function keyPressCharge(code) {
     }
 }
 
-function sendTrafficCostShortcut(item, defaultPrice) {
+function sendTrafficCostShortcut(item) {
     yearValue = $('#s_year').val();
     monthValue = $('#s_month').val();
     dayValue = $('#s_day').val();
     priceValue = $('#s_price').val();
     now = new Date();
     day = (yearValue == now.getFullYear() && monthValue == (now.getMonth() + 1) && dayValue.length == 0) ? now.getDate() : dayValue;
-    price = (priceValue.length == 0) ? defaultPrice : evaluateFormula(priceValue);
+    price = (priceValue.length == 0) ? 1000 : evaluateFormula(priceValue);
     $.post({
         url: add_api_url,
         data: {

--- a/moneybook/static/add.js
+++ b/moneybook/static/add.js
@@ -93,7 +93,7 @@ function sendTrafficCostShortcut(item) {
     priceValue = $('#s_price').val();
     now = new Date();
     day = (yearValue == now.getFullYear() && monthValue == (now.getMonth() + 1) && dayValue.length == 0) ? now.getDate() : dayValue;
-    price = (priceValue.length == 0) ? 1000 : evaluateFormula(priceValue);
+    price = (priceValue.length == 0) ? evaluateFormula($('#s_price').attr('placeholder')) : evaluateFormula(priceValue);
     $.post({
         url: add_api_url,
         data: {

--- a/moneybook/static/add.js
+++ b/moneybook/static/add.js
@@ -86,14 +86,14 @@ function keyPressCharge(code) {
     }
 }
 
-function sendTrafficCostShortcut(item) {
+function sendTrafficCostShortcut(item, defaultPrice) {
     yearValue = $('#s_year').val();
     monthValue = $('#s_month').val();
     dayValue = $('#s_day').val();
     priceValue = $('#s_price').val();
     now = new Date();
     day = (yearValue == now.getFullYear() && monthValue == (now.getMonth() + 1) && dayValue.length == 0) ? now.getDate() : dayValue;
-    price = (priceValue.length == 0) ? 3000 : evaluateFormula(priceValue);
+    price = (priceValue.length == 0) ? defaultPrice : evaluateFormula(priceValue);
     $.post({
         url: add_api_url,
         data: {

--- a/moneybook/templates/add.html
+++ b/moneybook/templates/add.html
@@ -117,13 +117,13 @@
             </tr>
             <tr>
                 <th>金額</th>
-                <td><input type="text" id="s_price" style="width:16ex" class="righter" placeholder="3000">円</td>
+                <td><input type="text" id="s_price" style="width:16ex" class="righter" placeholder="1000">円</td>
             </tr>
             <tr>
                 <th>項目</th>
                 <td>
-                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('Suicaチャージ')" value="Suicaチャージ">
-                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('電車代')" value="電車代">
+                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('Suicaチャージ', 1000)" value="Suicaチャージ">
+                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('電車代', 1000)" value="電車代">
                 </td>
             </tr>
         </table>

--- a/moneybook/templates/add.html
+++ b/moneybook/templates/add.html
@@ -122,8 +122,8 @@
             <tr>
                 <th>項目</th>
                 <td>
-                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('Suicaチャージ', 1000)" value="Suicaチャージ">
-                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('電車代', 1000)" value="電車代">
+                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('Suicaチャージ')" value="Suicaチャージ">
+                    <input type="button" class="btn-green" onclick="sendTrafficCostShortcut('電車代')" value="電車代">
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
Suicaチャージと電車代のショートカットのデフォルト金額を1000円に変更しました。
また、UI上の金額入力欄のプレースホルダーも1000に変更しました。
これに伴い、関連するE2Eテストも更新し、正常に動作することを確認済みです。

---
*PR created automatically by Jules for task [13308784663557700331](https://jules.google.com/task/13308784663557700331) started by @tMorriss*