### PR TITLE
[skip ci] Migrate Playwright tests to use web-first assertions

### DIFF
--- a/moneybook/playwright/base.py
+++ b/moneybook/playwright/base.py
@@ -53,12 +53,10 @@ class PlaywrightBase(StaticLiveServerTestCase):
         ]
         links = self.page.locator('nav.task_bar > ul > li > a')
         expect(links).to_have_count(len(expected_links))
+        expect(links).to_have_text([link['text'] for link in expected_links])
         for i in range(len(expected_links)):
             expect(links.nth(i)).to_have_attribute('href', self.live_server_url + expected_links[i]['href'])
-            expect(links.nth(i)).to_have_text(expected_links[i]['text'])
 
     def _assert_texts(self, actual_elements, expected_texts):
         # actual_elements が Locator の場合を想定
-        expect(actual_elements).to_have_count(len(expected_texts))
-        for i in range(len(expected_texts)):
-            expect(actual_elements.nth(i)).to_have_text(expected_texts[i])
+        expect(actual_elements).to_have_text(expected_texts)

--- a/moneybook/playwright/base.py
+++ b/moneybook/playwright/base.py
@@ -59,6 +59,4 @@ class PlaywrightBase(StaticLiveServerTestCase):
 
     def _assert_texts(self, actual_elements, expected_texts):
         # actual_elements が Locator の場合を想定
-        expect(actual_elements).to_have_count(len(expected_texts))
-        for i in range(len(expected_texts)):
-            expect(actual_elements.nth(i)).to_have_text(expected_texts[i])
+        expect(actual_elements).to_have_text(expected_texts)

--- a/moneybook/playwright/base.py
+++ b/moneybook/playwright/base.py
@@ -3,7 +3,7 @@ import os
 from django.contrib.auth.models import User
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.urls import reverse
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import expect, sync_playwright
 
 
 class PlaywrightBase(StaticLiveServerTestCase):
@@ -39,29 +39,26 @@ class PlaywrightBase(StaticLiveServerTestCase):
 
     def _assert_common(self):
         # アプリ名
-        self.assertEqual(self.page.inner_text('.header-cont1'), 'test-MoneyBook')
+        expect(self.page.locator('.header-cont1')).to_have_text('test-MoneyBook')
         # 名前表示
-        header_cont2_text = self.page.inner_text('.header-cont2')
-        self.assertTrue(self.username + 'さん' in header_cont2_text, header_cont2_text)
+        expect(self.page.locator('.header-cont2')).to_contain_text(self.username + 'さん')
 
         # タスクバー
-        expects = [
+        expected_links = [
             {'href': reverse('moneybook:index'), 'text': 'ホーム'},
             {'href': reverse('moneybook:add'), 'text': '追加'},
             {'href': reverse('moneybook:statistics'), 'text': '統計'},
             {'href': reverse('moneybook:search'), 'text': '検索'},
             {'href': reverse('moneybook:tools'), 'text': 'ツール'}
         ]
-        links = self.page.locator('nav.task_bar > ul > li > a').all()
-        self.assertEqual(len(links), len(expects))
-        for i in range(len(links)):
-            with self.subTest(i=i):
-                href = links[i].get_attribute('href')
-                self.assertEqual(href, self.live_server_url + expects[i]['href'])
-                self.assertEqual(links[i].inner_text(), expects[i]['text'])
+        links = self.page.locator('nav.task_bar > ul > li > a')
+        expect(links).to_have_count(len(expected_links))
+        for i in range(len(expected_links)):
+            expect(links.nth(i)).to_have_attribute('href', self.live_server_url + expected_links[i]['href'])
+            expect(links.nth(i)).to_have_text(expected_links[i]['text'])
 
-    def _assert_texts(self, actual_elements, expects):
-        self.assertEqual(len(actual_elements), len(expects))
-        for i in range(len(actual_elements)):
-            with self.subTest(i=i):
-                self.assertEqual(actual_elements[i].inner_text(), expects[i])
+    def _assert_texts(self, actual_elements, expected_texts):
+        # actual_elements が Locator の場合を想定
+        expect(actual_elements).to_have_count(len(expected_texts))
+        for i in range(len(expected_texts)):
+            expect(actual_elements.nth(i)).to_have_text(expected_texts[i])

--- a/moneybook/playwright/base.py
+++ b/moneybook/playwright/base.py
@@ -51,13 +51,14 @@ class PlaywrightBase(StaticLiveServerTestCase):
             {'href': reverse('moneybook:search'), 'text': '検索'},
             {'href': reverse('moneybook:tools'), 'text': 'ツール'}
         ]
-        import re
         links = self.page.locator('nav.task_bar > ul > li > a')
         expect(links).to_have_count(len(expected_links))
-        expect(links).to_have_text([link['text'] for link in expected_links])
         for i in range(len(expected_links)):
-            expect(links.nth(i)).to_have_attribute('href', re.compile(re.escape(expected_links[i]['href']) + '$'))
+            expect(links.nth(i)).to_have_attribute('href', self.live_server_url + expected_links[i]['href'])
+            expect(links.nth(i)).to_have_text(expected_links[i]['text'])
 
     def _assert_texts(self, actual_elements, expected_texts):
         # actual_elements が Locator の場合を想定
-        expect(actual_elements).to_have_text(expected_texts)
+        expect(actual_elements).to_have_count(len(expected_texts))
+        for i in range(len(expected_texts)):
+            expect(actual_elements.nth(i)).to_have_text(expected_texts[i])

--- a/moneybook/playwright/base.py
+++ b/moneybook/playwright/base.py
@@ -51,11 +51,12 @@ class PlaywrightBase(StaticLiveServerTestCase):
             {'href': reverse('moneybook:search'), 'text': '検索'},
             {'href': reverse('moneybook:tools'), 'text': 'ツール'}
         ]
+        import re
         links = self.page.locator('nav.task_bar > ul > li > a')
         expect(links).to_have_count(len(expected_links))
         expect(links).to_have_text([link['text'] for link in expected_links])
         for i in range(len(expected_links)):
-            expect(links.nth(i)).to_have_attribute('href', self.live_server_url + expected_links[i]['href'])
+            expect(links.nth(i)).to_have_attribute('href', re.compile(re.escape(expected_links[i]['href']) + '$'))
 
     def _assert_texts(self, actual_elements, expected_texts):
         # actual_elements が Locator の場合を想定

--- a/moneybook/playwright/login.py
+++ b/moneybook/playwright/login.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
-from playwright.sync_api import expect
 from moneybook.playwright.base import PlaywrightBase
+from playwright.sync_api import expect
 
 
 class Login(PlaywrightBase):

--- a/moneybook/playwright/login.py
+++ b/moneybook/playwright/login.py
@@ -1,14 +1,14 @@
 from django.urls import reverse
+from playwright.sync_api import expect
 from moneybook.playwright.base import PlaywrightBase
 
 
 class Login(PlaywrightBase):
     def _assert_login_success(self):
         # ログインできたらトップに移動
-        self.assertEqual(self.page.url, self.live_server_url + reverse('moneybook:index'))
+        expect(self.page).to_have_url(self.live_server_url + reverse('moneybook:index'))
         # 名前表示
-        header_cont2_text = self.page.inner_text('.header-cont2')
-        self.assertTrue(self.username + 'さん' in header_cont2_text, header_cont2_text)
+        expect(self.page.locator('.header-cont2')).to_contain_text(self.username + 'さん')
 
     def test_login_button(self):
         self._login()


### PR DESCRIPTION
The Playwright test suite was using Django's standard unit test assertions, which do not benefit from Playwright's auto-retry capabilities. This change migrates `moneybook/playwright/base.py` and `moneybook/playwright/login.py` to use `expect` from `playwright.sync_api`.

Key changes:
- `self.assertEqual(self.page.url, ...)` -> `expect(self.page).to_have_url(...)`
- `self.page.inner_text(...)` + `assertEqual` -> `expect(self.page.locator(...)).to_have_text(...)`
- `_assert_texts` was updated to accept a `Locator` object instead of a list of elements, allowing it to perform assertions on multiple elements with auto-retry.
- Removed `self.subTest` in loops within `_assert_common` as they are less applicable with Playwright's atomic assertions.

These changes improve test stability by allowing Playwright to wait for elements and states to be reached before failing.

---
*PR created automatically by Jules for task [10479668310750194541](https://jules.google.com/task/10479668310750194541) started by @tMorriss*