### PR TITLE
httpのimport方法修正

### DIFF
--- a/moneybook/views/add_api_view.py
+++ b/moneybook/views/add_api_view.py
@@ -1,5 +1,4 @@
 import calendar
-import http
 from datetime import date
 from http import HTTPStatus
 
@@ -26,7 +25,7 @@ class AddApiView(View):
             res_data = {
                 'ErrorList': error_list,
             }
-            return JsonResponse(res_data, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse(res_data, status=HTTPStatus.BAD_REQUEST)
 
 
 class AddIntraMoveApiView(View):
@@ -63,21 +62,21 @@ class AddIntraMoveApiView(View):
                 return JsonResponse({})
 
             except:
-                return JsonResponse({}, status=http.HTTPStatus.BAD_REQUEST)
+                return JsonResponse({}, status=HTTPStatus.BAD_REQUEST)
         else:
-            return JsonResponse({}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({}, status=HTTPStatus.BAD_REQUEST)
 
 
 class SuggestApiView(View):
     def get(self, request, *args, **kwargs):
         if 'item' not in request.GET:
             res = {'message': 'missing item'}
-            return JsonResponse(res, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse(res, status=HTTPStatus.BAD_REQUEST)
 
         item = request.GET.get('item')
         if item == '':
             res = {'message': 'empty item'}
-            return JsonResponse(res, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse(res, status=HTTPStatus.BAD_REQUEST)
 
         data = Data.sort_descending(
             Data.get_startswith_keyword_data(Data.get_all_data(), item))

--- a/moneybook/views/delete_api_view.py
+++ b/moneybook/views/delete_api_view.py
@@ -1,4 +1,4 @@
-import http
+from http import HTTPStatus
 
 from django.http import JsonResponse
 from django.views import View
@@ -13,6 +13,6 @@ class DeleteApiView(View):
             Data.get(pk).delete()
         except:
             res = {'message': 'Data does not exist'}
-            return JsonResponse(res, status=http.HTTPStatus.NOT_FOUND)
+            return JsonResponse(res, status=HTTPStatus.NOT_FOUND)
 
         return JsonResponse({})

--- a/moneybook/views/edit_api_view.py
+++ b/moneybook/views/edit_api_view.py
@@ -1,4 +1,4 @@
-import http
+from http import HTTPStatus
 
 from django.http import JsonResponse
 from django.views import View
@@ -13,7 +13,7 @@ class EditApiView(View):
         try:
             data = Data.get(pk)
         except:
-            return JsonResponse({'message': 'Data does not exist'}, status=http.HTTPStatus.NOT_FOUND)
+            return JsonResponse({'message': 'Data does not exist'}, status=HTTPStatus.NOT_FOUND)
 
         new_data = DataForm(request.POST)
         if new_data.is_valid():
@@ -35,7 +35,7 @@ class EditApiView(View):
             for a in new_data.errors:
                 error_list.append(a)
             res_data['ErrorList'] = error_list
-            return JsonResponse(res_data, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse(res_data, status=HTTPStatus.BAD_REQUEST)
 
 
 class ApplyCheckApiView(View):
@@ -61,7 +61,7 @@ class PreCheckApiView(View):
             data = Data.get(pk)
         except:
             res = {'message': 'Data does not exist'}
-            return JsonResponse(res, status=http.HTTPStatus.NOT_FOUND)
+            return JsonResponse(res, status=HTTPStatus.NOT_FOUND)
 
         if status == '1':
             data.pre_checked = True

--- a/moneybook/views/index_view.py
+++ b/moneybook/views/index_view.py
@@ -1,5 +1,5 @@
-import http
 from datetime import datetime
+from http import HTTPStatus
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -66,9 +66,9 @@ class IndexBalanceStatisticMiniView(View):
             year = request.GET.get('year')
             month = request.GET.get('month')
             if not is_valid_date(year, month):
-                return JsonResponse({'message': 'parameter error'}, status=http.HTTPStatus.BAD_REQUEST)
+                return JsonResponse({'message': 'parameter error'}, status=HTTPStatus.BAD_REQUEST)
         else:
-            return JsonResponse({'message': 'parameter error'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'parameter error'}, status=HTTPStatus.BAD_REQUEST)
 
         # 全データ
         all_data = Data.get_all_data()
@@ -137,9 +137,9 @@ class IndexChartDataView(View):
             year = request.GET.get('year')
             month = request.GET.get('month')
             if not is_valid_date(year, month):
-                return JsonResponse({'message': 'parameter error'}, status=http.HTTPStatus.BAD_REQUEST)
+                return JsonResponse({'message': 'parameter error'}, status=HTTPStatus.BAD_REQUEST)
         else:
-            return JsonResponse({'message': 'parameter error'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'parameter error'}, status=HTTPStatus.BAD_REQUEST)
 
         # 今月のデータ
         monthly_data = Data.get_month_data(int(year), int(month))
@@ -163,9 +163,9 @@ class DataTableView(View):
             year = request.GET.get('year')
             month = request.GET.get('month')
             if not is_valid_date(year, month):
-                return JsonResponse({'message': 'parameter error'}, status=http.HTTPStatus.BAD_REQUEST)
+                return JsonResponse({'message': 'parameter error'}, status=HTTPStatus.BAD_REQUEST)
         else:
-            return JsonResponse({'message': 'parameter error'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'parameter error'}, status=HTTPStatus.BAD_REQUEST)
 
         # 今月のデータ
         monthly_data = Data.sort_descending(

--- a/moneybook/views/tools_api_view.py
+++ b/moneybook/views/tools_api_view.py
@@ -1,5 +1,5 @@
-import http
 from datetime import date
+from http import HTTPStatus
 
 from django.http import JsonResponse
 from django.views import View
@@ -9,12 +9,12 @@ from moneybook.models import BankBalance, CheckedDate, CreditCheckedDate, Data, 
 class ActualCashApiView(View):
     def post(self, request, *args, **kwargs):
         if 'price' not in request.POST:
-            return JsonResponse({'message': 'missing parameter'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'missing parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         try:
             price = int(request.POST.get('price'))
         except ValueError:
-            return JsonResponse({'message': 'price must be int'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'price must be int'}, status=HTTPStatus.BAD_REQUEST)
 
         SeveralCosts.set_actual_cash_balance(price)
         return JsonResponse({})
@@ -46,7 +46,7 @@ class CheckedDateApiView(View):
 
     def post(self, request, *args, **kwargs):
         if 'year' not in request.POST or 'month' not in request.POST or 'day' not in request.POST or 'method' not in request.POST:
-            return JsonResponse({'message': 'missing parameter'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'missing parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         method_pk = request.POST.get('method')
         try:
@@ -58,13 +58,13 @@ class CheckedDateApiView(View):
                 Data.filter_checkeds(Data.get_method_data(Data.get_range_data(
                     None, new_date), method_pk), [False]).update(checked=True)
         except ValueError:
-            return JsonResponse({'message': 'date format is invalid'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'date format is invalid'}, status=HTTPStatus.BAD_REQUEST)
 
         try:
             # チェック日を更新
             CheckedDate.set(method_pk, new_date)
         except CheckedDate.DoesNotExist:
-            return JsonResponse({'message': 'method id is invalid'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'method id is invalid'}, status=HTTPStatus.BAD_REQUEST)
 
         return JsonResponse({})
 
@@ -72,20 +72,20 @@ class CheckedDateApiView(View):
 class CreditCheckedDateApiView(View):
     def post(self, request, *args, **kwargs):
         if 'year' not in request.POST or 'month' not in request.POST or 'day' not in request.POST or 'pk' not in request.POST:
-            return JsonResponse({'message': 'missing parameter'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'missing parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         pk = request.POST.get('pk')
         try:
             new_date = date(int(request.POST.get('year')), int(
                 request.POST.get('month')), int(request.POST.get('day')))
         except ValueError:
-            return JsonResponse({'message': 'date format is invalid'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'date format is invalid'}, status=HTTPStatus.BAD_REQUEST)
 
         try:
             # 更新
             CreditCheckedDate.set_date(pk, new_date)
         except CreditCheckedDate.DoesNotExist:
-            return JsonResponse({'message': 'method id is invalid'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'method id is invalid'}, status=HTTPStatus.BAD_REQUEST)
 
         return JsonResponse({})
 
@@ -93,12 +93,12 @@ class CreditCheckedDateApiView(View):
 class LivingCostMarkApiView(View):
     def post(self, request, *args, **kwargs):
         if 'price' not in request.POST:
-            return JsonResponse({'message': 'missing parameter'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'missing parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         try:
             price = int(request.POST.get('price'))
         except ValueError:
-            return JsonResponse({'message': 'price must be int'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'price must be int'}, status=HTTPStatus.BAD_REQUEST)
 
         SeveralCosts.set_living_cost_mark(price)
         return JsonResponse({'message': 'success'})
@@ -124,7 +124,7 @@ class NowBankApiView(View):
                 if key in request.POST:
                     int(request.POST.get(key))
         except ValueError:
-            return JsonResponse({'message': 'invalid parameter'}, status=http.HTTPStatus.BAD_REQUEST)
+            return JsonResponse({'message': 'invalid parameter'}, status=HTTPStatus.BAD_REQUEST)
 
         # 更新と計算
         for b in bb:

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
 [testenv:lint]
 deps = -r{toxinidir}/requirements/requirements_lint.txt
 commands =
-    flake8 . --count --exclude moneybook/migrations,__init__.py,.tox --show-source --statistics --import-order-style smarkets
+    flake8 . --count --exclude moneybook/migrations,__init__.py,.tox,.venv --show-source --statistics --import-order-style smarkets
     python check_filenames.py
 
 [testenv:unittest]
@@ -26,7 +26,7 @@ commands =
 deps =
     -r{toxinidir}/requirements/requirements.txt
     -r{toxinidir}/requirements/requirements_e2e.txt
-passenv = 
+passenv =
     HEADLESS
     TEST_MODULE
 commands =


### PR DESCRIPTION
`import http`と`from http import HTTPStatus`が混在していたので`from http import HTTPStatus`に統一

ついでにローカルでlint回すときに.venvディレクトリが入ってきて邪魔だったので除外対象とする