### PR TITLE
[skip ci] E2EテストのデータベースをPostgreSQLに変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,27 @@ jobs:
             periodic,
             search,
           ]
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: moneybook_e2e
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       TEST_MODULE: moneybook.e2e.${{ matrix.test-module }}
+      DB_NAME: moneybook_e2e
+      DB_USER: postgres
+      DB_PASS: postgres
+      DB_HOST: localhost
+      DB_PORT: 5432
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v2
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v2
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v2
       - name: Validate __init__.py
         run: |
           chmod +x check_init_py.sh
@@ -37,7 +37,7 @@ jobs:
     name: check e2e matrix configuration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v2
       - name: Install yq
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
@@ -50,9 +50,9 @@ jobs:
     name: unit test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v2
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v2
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
         run: |
           tox -e unittest
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
   e2e:
@@ -106,9 +106,9 @@ jobs:
       DB_HOST: localhost
       DB_PORT: 5432
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v2
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v2
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -119,7 +119,7 @@ jobs:
         run: |
           tox -e e2e
       - name: Upload e2e artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: e2e-artifacts-${{ matrix.test-module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Validate __init__.py
         run: |
           chmod +x check_init_py.sh
@@ -37,7 +37,7 @@ jobs:
     name: check e2e matrix configuration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install yq
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
@@ -50,9 +50,9 @@ jobs:
     name: unit test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
         run: |
           tox -e unittest
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
   e2e:
@@ -106,9 +106,9 @@ jobs:
       DB_HOST: localhost
       DB_PORT: 5432
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -119,7 +119,7 @@ jobs:
         run: |
           tox -e e2e
       - name: Upload e2e artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: e2e-artifacts-${{ matrix.test-module }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ $ tox -e unittest
 
 ## e2e テスト
 
+e2e テストは PostgreSQL を使用します。テストを実行する前に、以下のコマンドで PostgreSQL コンテナを起動してください。
+
+```
+$ docker run --rm -d -p 5432:5432 -e POSTGRES_DB=moneybook_e2e -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres --name moneybook-postgres-e2e postgres:15
+```
+
 e2e テストはデフォルトでヘッドレスモードで実行されます。
 
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ $ HEADLESS=0 TEST_MODULE=moneybook.e2e.index tox -e e2e
 $ $env:HEADLESS="0"; $env:TEST_MODULE="moneybook.e2e.index"; tox -e e2e
 ```
 
+### 他
+
+```
+## デバッグログ
+# mac
+$ EXTRA_OPTIONS="-v 2"
+
+# windows
+$env:EXTRA_OPTIONS="-v 2"
+```
+
 ## メモ
 
 ### venv

--- a/README.md
+++ b/README.md
@@ -62,17 +62,6 @@ $ HEADLESS=0 TEST_MODULE=moneybook.e2e.index tox -e e2e
 $ $env:HEADLESS="0"; $env:TEST_MODULE="moneybook.e2e.index"; tox -e e2e
 ```
 
-### 他
-
-```
-## デバッグログ
-# mac
-$ EXTRA_OPTIONS="-v 2"
-
-# windows
-$env:EXTRA_OPTIONS="-v 2"
-```
-
 ## メモ
 
 ### venv

--- a/config/settings/e2e.py
+++ b/config/settings/e2e.py
@@ -1,0 +1,20 @@
+import os
+
+from .common import *  # NOQA F403
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ.get('DB_NAME', 'moneybook_e2e'),
+        'USER': os.environ.get('DB_USER', 'postgres'),
+        'PASSWORD': os.environ.get('DB_PASS', 'postgres'),
+        'HOST': os.environ.get('DB_HOST', 'localhost'),
+        'PORT': os.environ.get('DB_PORT', '5432'),
+    }
+}
+
+APP_NAME = 'e2e-MoneyBook'
+
+DEBUG = True
+
+SECRET_KEY = 'secret_key_for_e2e_testing'

--- a/config/settings/e2e.py
+++ b/config/settings/e2e.py
@@ -1,5 +1,7 @@
 import os
 
+from django.core.management.utils import get_random_secret_key
+
 from .common import *  # NOQA F403
 
 DATABASES = {
@@ -17,4 +19,4 @@ APP_NAME = 'e2e-MoneyBook'
 
 DEBUG = True
 
-SECRET_KEY = 'secret_key_for_e2e_testing'
+SECRET_KEY = get_random_secret_key()

--- a/moneybook/e2e/base.py
+++ b/moneybook/e2e/base.py
@@ -70,7 +70,7 @@ class PlaywrightBase(StaticLiveServerTestCase):
 
     def _assert_common(self):
         # アプリ名
-        expect(self.page.locator('body > header .header-cont1')).to_have_text('test-MoneyBook')
+        expect(self.page.locator('body > header .header-cont1')).to_have_text('e2e-MoneyBook')
         # 名前表示
         expect(self.page.locator('body > header .header-cont2')).to_contain_text(self.username + 'さん')
 

--- a/moneybook/e2e/base.py
+++ b/moneybook/e2e/base.py
@@ -48,7 +48,7 @@ class PlaywrightBase(StaticLiveServerTestCase):
             screenshot_path = os.path.join(artifact_dir, f'{self.__class__.__name__}.{self._testMethodName}_failure.png')
             self.page.screenshot(path=screenshot_path)
 
-            filename = f'{self.__class__.__name__}.{self._testMethodName}_retry0.zip'
+            filename = f'{self.__class__.__name__}.{self._testMethodName}.zip'
             self.context.tracing.stop(path=os.path.join(artifact_dir, filename))
         else:
             self.context.tracing.stop()
@@ -66,7 +66,7 @@ class PlaywrightBase(StaticLiveServerTestCase):
         self.page.fill('#id_password', self.password)
         # ログインボタンをクリック。遷移を待つ。
         self.page.click('input[value="ログイン"]')
-        # ログイン成功の証拠（ログアウトリンクの存在）を待つ。タイムアウトはデフォルト(30s)
+        # ログイン成功の証拠（ログアウトリンクの存在）を待つ。
         self.page.wait_for_selector('a[href="' + reverse('moneybook:logout') + '"]')
 
     def _assert_common(self):

--- a/moneybook/e2e/base.py
+++ b/moneybook/e2e/base.py
@@ -1,5 +1,6 @@
 import os
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.urls import reverse
@@ -47,7 +48,7 @@ class PlaywrightBase(StaticLiveServerTestCase):
             screenshot_path = os.path.join(artifact_dir, f'{self.__class__.__name__}.{self._testMethodName}_failure.png')
             self.page.screenshot(path=screenshot_path)
 
-            filename = f'{self.__class__.__name__}.{self._testMethodName}.zip'
+            filename = f'{self.__class__.__name__}.{self._testMethodName}_retry0.zip'
             self.context.tracing.stop(path=os.path.join(artifact_dir, filename))
         else:
             self.context.tracing.stop()
@@ -65,12 +66,12 @@ class PlaywrightBase(StaticLiveServerTestCase):
         self.page.fill('#id_password', self.password)
         # ログインボタンをクリック。遷移を待つ。
         self.page.click('input[value="ログイン"]')
-        # ログイン成功の証拠（ログアウトリンクの存在）を待つ。
+        # ログイン成功の証拠（ログアウトリンクの存在）を待つ。タイムアウトはデフォルト(30s)
         self.page.wait_for_selector('a[href="' + reverse('moneybook:logout') + '"]')
 
     def _assert_common(self):
         # アプリ名
-        expect(self.page.locator('body > header .header-cont1')).to_have_text('e2e-MoneyBook')
+        expect(self.page.locator('body > header .header-cont1')).to_have_text(settings.APP_NAME)
         # 名前表示
         expect(self.page.locator('body > header .header-cont2')).to_contain_text(self.username + 'さん')
 

--- a/moneybook/e2e/index.py
+++ b/moneybook/e2e/index.py
@@ -678,6 +678,8 @@ class Index(PlaywrightBase):
         # 収入カテゴリ (pk=7)
         self.page.click('#lbl_a_category-7')
         self.page.click('input[value="追加"]')
+        # 反映待ち
+        expect(self.page.locator('#summary-count')).to_have_text('1件')
 
         # 支出データ追加
         self.page.fill('#a_day', '2')
@@ -686,12 +688,13 @@ class Index(PlaywrightBase):
         # 食費カテゴリ (pk=1)
         self.page.click('#lbl_a_category-1')
         self.page.click('input[value="追加"]')
+        # 反映待ち
+        expect(self.page.locator('#summary-count')).to_have_text('2件')
 
         # 成功メッセージが表示されるのを待つ
         expect(self.page.locator('#result_message')).to_contain_text('Success!')
 
         # サマリー確認
-        expect(self.page.locator('#summary-count')).to_have_text('2件')
         expect(self.page.locator('#summary-income')).to_have_text('収入: 1,000円')
         expect(self.page.locator('#summary-outgo')).to_have_text('支出: 500円')
 

--- a/requirements/requirements_e2e.txt
+++ b/requirements/requirements_e2e.txt
@@ -1,2 +1,3 @@
 playwright
 pyyaml
+psycopg2-binary

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,14 @@ deps =
 passenv =
     HEADLESS
     TEST_MODULE
+    DB_NAME
+    DB_USER
+    DB_PASS
+    DB_HOST
+    DB_PORT
 commands =
     playwright install --with-deps chromium
-    python manage.py test {env:TEST_MODULE:moneybook.e2e} --settings config.settings.test
+    python manage.py test {env:TEST_MODULE:moneybook.e2e} --settings config.settings.e2e
 
 [flake8]
 max-line-length = 140

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ deps =
 passenv =
     HEADLESS
     TEST_MODULE
-    EXTRA_OPTIONS
     DB_NAME
     DB_USER
     DB_PASS
@@ -37,7 +36,7 @@ passenv =
     DB_PORT
 commands =
     playwright install --with-deps chromium
-    python manage.py test {env:TEST_MODULE:moneybook.e2e} --settings config.settings.e2e {env:EXTRA_OPTIONS:}
+    python manage.py test {env:TEST_MODULE:moneybook.e2e} --settings config.settings.e2e
 
 [flake8]
 max-line-length = 140

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
 passenv =
     HEADLESS
     TEST_MODULE
+    EXTRA_OPTIONS
     DB_NAME
     DB_USER
     DB_PASS
@@ -36,7 +37,7 @@ passenv =
     DB_PORT
 commands =
     playwright install --with-deps chromium
-    python manage.py test {env:TEST_MODULE:moneybook.e2e} --settings config.settings.e2e
+    python manage.py test {env:TEST_MODULE:moneybook.e2e} --settings config.settings.e2e {env:EXTRA_OPTIONS:}
 
 [flake8]
 max-line-length = 140


### PR DESCRIPTION
E2EテストのデータベースをSQLiteからPostgreSQLに移行しました。
以下の変更を行いました：
- E2E専用のDjango設定ファイル `config/settings/e2e.py` の作成
- `requirements/requirements_e2e.txt` への `psycopg2-binary` の追加
- `tox.ini` の更新（E2E設定の使用と環境変数の引き継ぎ）
- GitHub Actions（`.github/workflows/ci.yml`）への PostgreSQL サービスの追加
- `README.md` へのローカル実行用 Docker コマンドの追記

単体テスト（unittest）は引き続き SQLite を使用するように維持しています。

---
*PR created automatically by Jules for task [16273512552494704341](https://jules.google.com/task/16273512552494704341) started by @tMorriss*