### PR TITLE
[skip ci] HTTPステータスコードの http.HTTPStatus への統一

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,10 @@ HEADLESS=0 tox -e e2e
 
 1. **設定の分離**: 環境別設定を`config/settings/`で管理
 2. **静的ファイル**: `{% static %}`タグを使用してパスを生成
+3. **HTTPステータスコード**: ステータスコードを指定または検証する際は、数値（例: 200, 400）を直接使用せず、`http.HTTPStatus`を使用してください。
+   - インポート形式: `from http import HTTPStatus`
+   - 利用方法: `HTTPStatus.OK`, `HTTPStatus.BAD_REQUEST` など
+   - ただし、Djangoが提供する特定のステータスコード用クラス（例: `HttpResponseRedirect`）が利用可能な場合は、それらを使用しても構いません。
 
 ### CSS/スタイル規約
 

--- a/moneybook/e2e/edit.py
+++ b/moneybook/e2e/edit.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from http import HTTPStatus
 
 from django.urls import reverse
 from moneybook.e2e.base import PlaywrightBase
@@ -47,7 +48,7 @@ class Edit(PlaywrightBase):
             self.page.click(f'label[for="a_category-{category_id}"]')
 
         # 追加ボタンをクリック。APIのレスポンスを待つ
-        with self.page.expect_response(lambda r: '_data_table' in r.url and r.status == 200):
+        with self.page.expect_response(lambda r: '_data_table' in r.url and r.status == HTTPStatus.OK):
             self.page.click('input[value="追加"]')
 
         # テーブルの更新完了を待つ (追加した品目が表示されるまで)

--- a/moneybook/tests/views/add_api_view_tests.py
+++ b/moneybook/tests/views/add_api_view_tests.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date
+from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -24,7 +25,7 @@ class AddApiViewTestCase(BaseTestCase):
                 'checked': False
             }
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count + 1)
@@ -43,7 +44,7 @@ class AddApiViewTestCase(BaseTestCase):
                 'checked': False
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.content.decode(), json.dumps(
             {'ErrorList': ['date', 'price']}))
         after_count = Data.get_all_data().count()
@@ -64,7 +65,7 @@ class AddApiViewTestCase(BaseTestCase):
                 'checked': False
             }
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 
@@ -75,7 +76,7 @@ class SuggestApiViewTestCase(BaseTestCase):
         response = self.client.get(
             reverse('moneybook:suggest_api'), {'item': '必需品'})
 
-        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
         body = json.loads(response.content.decode())
 
         expects = {'suggests': [
@@ -90,7 +91,7 @@ class SuggestApiViewTestCase(BaseTestCase):
         response = self.client.get(
             reverse('moneybook:suggest_api'), {'item': 'PayPayチャージ'})
 
-        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
         body = json.loads(response.content.decode())
 
         expects = {'suggests': [
@@ -103,7 +104,7 @@ class SuggestApiViewTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:suggest_api'))
 
-        self.assertEqual(response.status_code, 400, response.content)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
         body = json.loads(response.content.decode())
         self.assertEqual(body, {'message': 'missing item'})
 
@@ -112,7 +113,7 @@ class SuggestApiViewTestCase(BaseTestCase):
         response = self.client.get(
             reverse('moneybook:suggest_api'), {'item': ''})
 
-        self.assertEqual(response.status_code, 400, response.content)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
         body = json.loads(response.content.decode())
         self.assertEqual(body, {'message': 'empty item'})
 
@@ -157,7 +158,7 @@ class AddPeriodicApiViewTestCase(BaseTestCase):
             'month': month
         })
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # データが2件追加されていること
         self.assertEqual(Data.objects.count(), initial_count + 2)
@@ -200,7 +201,7 @@ class AddPeriodicApiViewTestCase(BaseTestCase):
             'year': year,
             'month': month
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # 31日が29日に調整されていること
         data = Data.objects.get(item='月末払い', date=date(2024, 2, 29))
@@ -212,32 +213,32 @@ class AddPeriodicApiViewTestCase(BaseTestCase):
             'year': 'invalid',
             'month': 2
         })
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         response = self.client.post(reverse('moneybook:add_periodic_api'), {
             'year': 2024,
             'month': 'invalid'
         })
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         # 13月などの範囲外
         response = self.client.post(reverse('moneybook:add_periodic_api'), {
             'year': 2024,
             'month': 13
         })
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_add_periodic_missing_params(self):
         """パラメータ不足でエラーになること"""
         response = self.client.post(reverse('moneybook:add_periodic_api'), {
             'year': 2024
         })
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         response = self.client.post(reverse('moneybook:add_periodic_api'), {
             'month': 2
         })
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_add_periodic_guest(self):
         """未認証でエラーになること"""
@@ -246,4 +247,4 @@ class AddPeriodicApiViewTestCase(BaseTestCase):
             'year': 2024,
             'month': 4
         })
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)

--- a/moneybook/tests/views/add_intra_move_view_tests.py
+++ b/moneybook/tests/views/add_intra_move_view_tests.py
@@ -1,4 +1,5 @@
 from datetime import date
+from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -22,7 +23,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
                 'after_method': 3,
             }
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count + 2)
@@ -60,7 +61,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
                 'after_method': 3,
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
@@ -80,7 +81,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
                 'after_method': 3,
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
@@ -99,7 +100,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
                 'after_method': 3,
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
@@ -118,7 +119,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
                 'after_method': 3,
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
@@ -137,7 +138,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
                 'after_method': 3,
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
@@ -156,7 +157,7 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
                 'before_method': 2,
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
@@ -175,6 +176,6 @@ class AddIntraMoveApiViewTestCase(BaseTestCase):
                 'after_method': 3,
             }
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)

--- a/moneybook/tests/views/add_view_tests.py
+++ b/moneybook/tests/views/add_view_tests.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -10,7 +11,7 @@ class AddViewTestCase(BaseTestCase):
         now = datetime.now()
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:add'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['app_name'], 'test-MoneyBook')
         self.assertEqual(response.context['username'].username, self.username)
         self.assertEqual(response.context['year'], now.year)
@@ -32,5 +33,5 @@ class AddViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:add'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertRedirects(response, reverse('moneybook:login'))

--- a/moneybook/tests/views/add_view_tests.py
+++ b/moneybook/tests/views/add_view_tests.py
@@ -33,5 +33,4 @@ class AddViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:add'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertRedirects(response, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)

--- a/moneybook/tests/views/delete_api_view_tests.py
+++ b/moneybook/tests/views/delete_api_view_tests.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from django.contrib.auth.models import User
 from django.urls import reverse
 from moneybook.models import Data
@@ -9,7 +11,7 @@ class DeleteApiViewTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         before_count = Data.get_all_data().count()
         response = self.client.get(reverse('moneybook:delete_api'), {'pk': 1})
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 
@@ -17,7 +19,7 @@ class DeleteApiViewTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         before_count = Data.get_all_data().count()
         response = self.client.post(reverse('moneybook:delete_api'), {'pk': 1})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.content.decode(), '{}')
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count - 1)
@@ -26,13 +28,13 @@ class DeleteApiViewTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         before_count = Data.get_all_data().count()
         response = self.client.post(reverse('moneybook:delete_api'), {'pk': 100000})
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)
 
     def test_post_guest(self):
         before_count = Data.get_all_data().count()
         response = self.client.post(reverse('moneybook:delete_api'), {'pk': 1})
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         after_count = Data.get_all_data().count()
         self.assertEqual(after_count, before_count)

--- a/moneybook/tests/views/edit_view_tests.py
+++ b/moneybook/tests/views/edit_view_tests.py
@@ -31,13 +31,11 @@ class EditViewTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(
             reverse('moneybook:edit', kwargs={'pk': 10000}))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:index'))
+        self.assertRedirects(response, reverse('moneybook:index'), status_code=HTTPStatus.FOUND)
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:edit', kwargs={'pk': 1}))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class EditApiViewTestCase(BaseTestCase):

--- a/moneybook/tests/views/edit_view_tests.py
+++ b/moneybook/tests/views/edit_view_tests.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date
+from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -11,7 +12,7 @@ class EditViewTestCase(BaseTestCase):
     def test_get(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:edit', kwargs={'pk': 1}))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['app_name'], 'test-MoneyBook')
         self.assertEqual(response.context['username'].username, self.username)
         data = response.context['data']
@@ -30,12 +31,12 @@ class EditViewTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(
             reverse('moneybook:edit', kwargs={'pk': 10000}))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:index'))
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:edit', kwargs={'pk': 1}))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -66,7 +67,7 @@ class EditApiViewTestCase(BaseTestCase):
                 'checked': False
             }
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # 更新されていることを確認
         data = Data.get(1)
@@ -103,7 +104,7 @@ class EditApiViewTestCase(BaseTestCase):
                 'checked': False
             }
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         content_json = json.loads(response.content.decode())
         self.assertEqual(content_json['ErrorList'], ['date', 'price'])
 
@@ -133,7 +134,7 @@ class EditApiViewTestCase(BaseTestCase):
                 'checked': False
             }
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_post_guest(self):
         # 更新前の値を確認
@@ -159,7 +160,7 @@ class EditApiViewTestCase(BaseTestCase):
                 'checked': False
             }
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
         # 更新されていないことを確認
         data = Data.get(1)
@@ -192,7 +193,7 @@ class ApplyCheckApiViewTestCase(BaseTestCase):
 
         # ApplyCheckApiViewを実行
         response = self.client.post(reverse('moneybook:apply_check_api'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # 事前チェック済みデータがチェック済みになっていることを確認
         for pk in test_pks:
@@ -203,7 +204,7 @@ class ApplyCheckApiViewTestCase(BaseTestCase):
     def test_post_guest(self):
         response = self.client.post(reverse('moneybook:apply_check_api'))
         # apply_check_api is in the API list, so it should return 403
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
 
 class PreCheckApiViewTestCase(BaseTestCase):
@@ -217,7 +218,7 @@ class PreCheckApiViewTestCase(BaseTestCase):
             reverse('moneybook:pre_check_api'),
             {'id': 4, 'status': '1'}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         data = Data.get(4)
         self.assertEqual(data.pre_checked, True)
@@ -233,7 +234,7 @@ class PreCheckApiViewTestCase(BaseTestCase):
             reverse('moneybook:pre_check_api'),
             {'id': 4, 'status': '0'}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         data = Data.get(4)
         self.assertEqual(data.pre_checked, False)
@@ -244,7 +245,7 @@ class PreCheckApiViewTestCase(BaseTestCase):
             reverse('moneybook:pre_check_api'),
             {'id': 99999, 'status': '1'}
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_post_guest(self):
         response = self.client.post(
@@ -252,4 +253,4 @@ class PreCheckApiViewTestCase(BaseTestCase):
             {'id': 4, 'status': '1'}
         )
         # pre_check_api is in the API list, so it should return 403
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)

--- a/moneybook/tests/views/index_view_tests.py
+++ b/moneybook/tests/views/index_view_tests.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from http import HTTPStatus
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -20,7 +21,7 @@ class IndexViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:index'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -28,7 +29,7 @@ class IndexMonthViewTestCase(BaseTestCase):
     def test_get(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:index_month', kwargs={'year': 2000, 'month': 1}))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['app_name'], 'test-MoneyBook')
         self.assertEqual(
             response.context['username'].username, self.username)
@@ -58,18 +59,18 @@ class IndexMonthViewTestCase(BaseTestCase):
         now = datetime.now()
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:index_month', kwargs={'year': now.year, 'month': now.month}))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['day'], now.day)
 
     def test_get_out_of_range(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:index_month', kwargs={'year': 2000, 'month': 13}))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:index'))
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:index_month', kwargs={'year': 2000, 'month': 1}))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -77,7 +78,7 @@ class IndexBalanceStatisticMiniViewTestCase(BaseTestCase):
     def test_get(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:balance_statistic_mini'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['total_balance'], 46694)
         self.assertEqual(response.context['monthly_income'], 32993)
         self.assertEqual(response.context['monthly_outgo'], 7920)
@@ -120,26 +121,26 @@ class IndexBalanceStatisticMiniViewTestCase(BaseTestCase):
     def test_get_without_year(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:balance_statistic_mini'), {'month': 1})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_without_month(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:balance_statistic_mini'), {'year': 2000})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_out_of_range(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:balance_statistic_mini'), {'year': 2000, 'month': 13})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_without_parameters(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:balance_statistic_mini'))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:balance_statistic_mini'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -147,7 +148,7 @@ class IndexChartDataViewTestCase(BaseTestCase):
     def test_get(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:chart_container_data'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         positive_categories_outgo = response.context['categories_outgo']
         actials = [
             {'name': 'その他', 'value': 30},
@@ -165,26 +166,26 @@ class IndexChartDataViewTestCase(BaseTestCase):
     def test_get_wituout_year(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:chart_container_data'), {'month': 1})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_wituout_month(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:chart_container_data'), {'year': 2000})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_without_parameters(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:chart_container_data'))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_out_of_range(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:chart_container_data'), {'year': 2000, 'month': 13})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:chart_container_data'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -192,7 +193,7 @@ class DataTableViewTestCase(BaseTestCase):
     def test_get(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:data_table'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         expects = [
             '立替分2',
             '立替分1',
@@ -218,24 +219,24 @@ class DataTableViewTestCase(BaseTestCase):
     def test_get_without_year(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:data_table'), {'month': 1})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_without_month(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:data_table'), {'year': 2000})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_without_parameters(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:data_table'))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_out_of_range(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:data_table'), {'year': 2000, 'month': 13})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:data_table'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))

--- a/moneybook/tests/views/index_view_tests.py
+++ b/moneybook/tests/views/index_view_tests.py
@@ -21,8 +21,7 @@ class IndexViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:index'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class IndexMonthViewTestCase(BaseTestCase):
@@ -65,13 +64,11 @@ class IndexMonthViewTestCase(BaseTestCase):
     def test_get_out_of_range(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:index_month', kwargs={'year': 2000, 'month': 13}))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:index'))
+        self.assertRedirects(response, reverse('moneybook:index'), status_code=HTTPStatus.FOUND)
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:index_month', kwargs={'year': 2000, 'month': 1}))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class IndexBalanceStatisticMiniViewTestCase(BaseTestCase):
@@ -140,8 +137,7 @@ class IndexBalanceStatisticMiniViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:balance_statistic_mini'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class IndexChartDataViewTestCase(BaseTestCase):
@@ -185,8 +181,7 @@ class IndexChartDataViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:chart_container_data'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class DataTableViewTestCase(BaseTestCase):
@@ -238,5 +233,4 @@ class DataTableViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:data_table'), {'year': 2000, 'month': 1})
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)

--- a/moneybook/tests/views/period_balance_view_tests.py
+++ b/moneybook/tests/views/period_balance_view_tests.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -7,7 +8,7 @@ from moneybook.tests.base import BaseTestCase
 
 class PeriodBalanceViewTestCase(BaseTestCase):
     def _assert_without_draw(self, response):
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertFalse('period_balances' in response.context)
         self.assertFalse(response.context['draw_graph'])
         self.assertFalse('start_year' in response.context)
@@ -24,7 +25,7 @@ class PeriodBalanceViewTestCase(BaseTestCase):
 
     def _assert_now(self, response):
         now = datetime.now()
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         period_balances = response.context['period_balances']
         expects = []
         for i in range(12):
@@ -57,7 +58,7 @@ class PeriodBalanceViewTestCase(BaseTestCase):
                 'end_year': 2000, 'end_month': 5
             }
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         period_balances = response.context['period_balances']
         expects = [
             {'label': '2000-01', 'value': 24073},
@@ -92,7 +93,7 @@ class PeriodBalanceViewTestCase(BaseTestCase):
                 'end_year': 2000, 'end_month': 1
             }
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         period_balances = response.context['period_balances']
         expects = [
             {'label': '1999-10', 'value': 0},

--- a/moneybook/tests/views/period_balance_view_tests.py
+++ b/moneybook/tests/views/period_balance_view_tests.py
@@ -157,3 +157,7 @@ class PeriodBalanceViewTestCase(BaseTestCase):
             with self.subTest(b=b):
                 response = self.client.get(reverse('moneybook:period_balances'), b)
                 self._assert_without_draw(response)
+
+    def test_get_guest(self):
+        response = self.client.get(reverse('moneybook:period_balances'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)

--- a/moneybook/tests/views/periodic_edit_view_tests.py
+++ b/moneybook/tests/views/periodic_edit_view_tests.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from django.contrib.auth.models import User
 from django.urls import reverse
 from moneybook.models import Category, Direction, Method, PeriodicData
@@ -22,7 +24,7 @@ class PeriodicEditViewGetTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:periodic_edit'))
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['app_name'], 'test-MoneyBook')
 
         # 定期取引データが含まれていること
@@ -44,7 +46,7 @@ class PeriodicEditViewGetTestCase(BaseTestCase):
     def test_get_guest(self):
         """ログインしていない場合はログインページにリダイレクトされること"""
         response = self.client.get(reverse('moneybook:periodic_edit'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
 
 
 class PeriodicEditViewPostTestCase(BaseTestCase):
@@ -89,7 +91,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
         response = self.client.post(reverse('moneybook:periodic_edit'), data=post_data)
 
         # periodicにリダイレクトされること
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:periodic'))
 
         # データが更新されていること
@@ -117,7 +119,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
     def test_post_guest(self):
         """ログインしていない場合はログインページにリダイレクトされること"""
         response = self.client.post(reverse('moneybook:periodic_edit'), data={})
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
 
     def test_post_missing_required_field(self):
         """必須フィールド欠落時は行をスキップしてperiodicにリダイレクト"""
@@ -133,7 +135,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
         response = self.client.post(reverse('moneybook:periodic_edit'), data=post_data)
 
         # 必須フィールドがないので何も登録されず、periodicにリダイレクト
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:periodic'))
 
         # データが登録されていないこと
@@ -157,7 +159,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
         response = self.client.post(reverse('moneybook:periodic_edit'), data=post_data)
 
         # フォームがinvalidなので何も登録されず、periodicにリダイレクト
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:periodic'))
 
         # データが登録されていないこと

--- a/moneybook/tests/views/periodic_edit_view_tests.py
+++ b/moneybook/tests/views/periodic_edit_view_tests.py
@@ -164,3 +164,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
 
         # データが登録されていないこと
         self.assertEqual(PeriodicData.objects.count(), 0)
+
+    def test_get_guest(self):
+        response = self.client.get(reverse('moneybook:periodic_edit'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)

--- a/moneybook/tests/views/periodic_edit_view_tests.py
+++ b/moneybook/tests/views/periodic_edit_view_tests.py
@@ -91,8 +91,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
         response = self.client.post(reverse('moneybook:periodic_edit'), data=post_data)
 
         # periodicにリダイレクトされること
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:periodic'))
+        self.assertRedirects(response, reverse('moneybook:periodic'), status_code=HTTPStatus.FOUND)
 
         # データが更新されていること
         after_count = PeriodicData.objects.count()
@@ -119,7 +118,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
     def test_post_guest(self):
         """ログインしていない場合はログインページにリダイレクトされること"""
         response = self.client.post(reverse('moneybook:periodic_edit'), data={})
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
     def test_post_missing_required_field(self):
         """必須フィールド欠落時は行をスキップしてperiodicにリダイレクト"""
@@ -135,8 +134,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
         response = self.client.post(reverse('moneybook:periodic_edit'), data=post_data)
 
         # 必須フィールドがないので何も登録されず、periodicにリダイレクト
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:periodic'))
+        self.assertRedirects(response, reverse('moneybook:periodic'), status_code=HTTPStatus.FOUND)
 
         # データが登録されていないこと
         self.assertEqual(PeriodicData.objects.count(), 0)
@@ -159,8 +157,7 @@ class PeriodicEditViewPostTestCase(BaseTestCase):
         response = self.client.post(reverse('moneybook:periodic_edit'), data=post_data)
 
         # フォームがinvalidなので何も登録されず、periodicにリダイレクト
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:periodic'))
+        self.assertRedirects(response, reverse('moneybook:periodic'), status_code=HTTPStatus.FOUND)
 
         # データが登録されていないこと
         self.assertEqual(PeriodicData.objects.count(), 0)

--- a/moneybook/tests/views/periodic_view_tests.py
+++ b/moneybook/tests/views/periodic_view_tests.py
@@ -50,4 +50,4 @@ class PeriodicViewGetTestCase(BaseTestCase):
     def test_get_guest(self):
         """ログインしていない場合はログインページにリダイレクトされること"""
         response = self.client.get(reverse('moneybook:periodic'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)

--- a/moneybook/tests/views/periodic_view_tests.py
+++ b/moneybook/tests/views/periodic_view_tests.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from http import HTTPStatus
 
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import User
@@ -26,7 +27,7 @@ class PeriodicViewGetTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:periodic'))
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['app_name'], 'test-MoneyBook')
         self.assertEqual(response.context['username'].username, self.username)
 
@@ -49,4 +50,4 @@ class PeriodicViewGetTestCase(BaseTestCase):
     def test_get_guest(self):
         """ログインしていない場合はログインページにリダイレクトされること"""
         response = self.client.get(reverse('moneybook:periodic'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)

--- a/moneybook/tests/views/search_view_tests.py
+++ b/moneybook/tests/views/search_view_tests.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from django.contrib.auth.models import User
 from django.urls import reverse
 from moneybook.tests.base import BaseTestCase
@@ -5,7 +7,7 @@ from moneybook.tests.base import BaseTestCase
 
 class SearchViewTestCase(BaseTestCase):
     def _search_common(self, response):
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['app_name'], 'test-MoneyBook')
         self.assertEqual(response.context['username'].username, self.username)
         self._assert_all_directions(response)
@@ -92,7 +94,7 @@ class SearchViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:search'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
     def test_get_new_only_is_query(self):

--- a/moneybook/tests/views/search_view_tests.py
+++ b/moneybook/tests/views/search_view_tests.py
@@ -94,8 +94,7 @@ class SearchViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:search'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
     def test_get_new_only_is_query(self):
         """is_queryだけ指定すると全データ表示される"""

--- a/moneybook/tests/views/statistics_view_tests.py
+++ b/moneybook/tests/views/statistics_view_tests.py
@@ -20,8 +20,7 @@ class StatisticsViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:statistics'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class StatisticsMonthViewTestCase(BaseTestCase):
@@ -124,5 +123,4 @@ class StatisticsMonthViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:statistics_month', kwargs={'year': 2000}))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)

--- a/moneybook/tests/views/statistics_view_tests.py
+++ b/moneybook/tests/views/statistics_view_tests.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from http import HTTPStatus
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -19,7 +20,7 @@ class StatisticsViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:statistics'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -29,7 +30,7 @@ class StatisticsMonthViewTestCase(BaseTestCase):
         response = self.client.get(
             reverse('moneybook:statistics_month', kwargs={'year': 2000}))
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['app_name'], 'test-MoneyBook')
         self.assertEqual(response.context['username'].username, self.username)
         self.assertEqual(response.context['year'], 2000)
@@ -115,7 +116,7 @@ class StatisticsMonthViewTestCase(BaseTestCase):
     def test_get_december_water(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:statistics_month', kwargs={'year': 1999}))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         monthly_context = response.context['monthly_context']
         self.assertEqual(len(monthly_context), 12)
@@ -123,5 +124,5 @@ class StatisticsMonthViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:statistics_month', kwargs={'year': 2000}))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))

--- a/moneybook/tests/views/tools_view_tests.py
+++ b/moneybook/tests/views/tools_view_tests.py
@@ -28,8 +28,7 @@ class ToolsViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:tools'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class ActualCashApiViewTestCase(BaseTestCase):
@@ -334,8 +333,7 @@ class SeveralCheckedDateViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:several_checked_date'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class CreditCheckedDateApiViewTestCase(BaseTestCase):
@@ -517,8 +515,7 @@ class UncheckedDataViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:unchecked_data'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)
 
 
 class NowBankApiViewTestCase(BaseTestCase):

--- a/moneybook/tests/views/tools_view_tests.py
+++ b/moneybook/tests/views/tools_view_tests.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date, datetime
+from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -13,7 +14,7 @@ class ToolsViewTestCase(BaseTestCase):
 
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:tools'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['app_name'], 'test-MoneyBook')
         self.assertEqual(response.context['username'].username, self.username)
         self.assertEqual(response.context['cash_balance'], -3930)
@@ -27,7 +28,7 @@ class ToolsViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:tools'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -36,27 +37,27 @@ class ActualCashApiViewTestCase(BaseTestCase):
         self.client.force_login(User.objects.create_user(self.username))
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 2000)
         response = self.client.post(reverse('moneybook:actual_cash_api'), {'price': 1200})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 1200)
 
     def test_post_str(self):
         self.client.force_login(User.objects.create_user(self.username))
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 2000)
         response = self.client.post(reverse('moneybook:actual_cash_api'), {'price': 'a'})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 2000)
 
     def test_post_missing(self):
         self.client.force_login(User.objects.create_user(self.username))
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 2000)
         response = self.client.post(reverse('moneybook:actual_cash_api'))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 2000)
 
     def test_post_guest(self):
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 2000)
         response = self.client.post(reverse('moneybook:actual_cash_api'), {'price': 1200})
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(SeveralCosts.get_actual_cash_balance(), 2000)
 
 
@@ -64,7 +65,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
     def test_get(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:checked_date_api'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content_json = json.loads(response.content.decode())
         methods_bd = content_json['methods_bd']
         expects = [
@@ -116,7 +117,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2001, 'month': 2, 'day': 20, 'method': 2}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(CheckedDate.get(2).date, date(2001, 2, 20))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -132,7 +133,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2000, 'month': 1, 'day': 20, 'method': 2, 'check_all': 1}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 20))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         expects = ['スーパー', 'PayPayチャージ', '立替分1', '内部移動1', '内部移動2']
@@ -149,7 +150,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2000, 'month': 1, 'day': 20, 'method': 2, 'check_all': 2}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 20))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -165,7 +166,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2000, 'month': 1, 'day': 40, 'method': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -181,7 +182,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'month': 1, 'day': 40, 'method': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -197,7 +198,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2000, 'month': 1, 'method': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -213,7 +214,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2000, 'month': 1, 'day': 20}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -229,7 +230,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 'a', 'month': 1, 'day': 40, 'method': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -245,7 +246,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2000, 'month': 'a', 'day': 40, 'method': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -261,7 +262,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2000, 'month': 1, 'day': 'a', 'method': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -277,7 +278,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2000, 'month': 1, 'day': 20, 'method': 1000000}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
         self._assert_list(unchecked_data, expects)
@@ -291,7 +292,7 @@ class CheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:checked_date_api'),
             {'year': 2001, 'month': 2, 'day': 20, 'method': 2}
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
         self.assertEqual(CheckedDate.get(2).date, date(2000, 1, 5))
         unchecked_data = Data.get_unchecked_data(Data.get_all_data())
@@ -303,7 +304,7 @@ class SeveralCheckedDateViewTestCase(BaseTestCase):
         now = datetime.now()
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:several_checked_date'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['year'], now.year)
 
         banks = response.context['banks']
@@ -333,7 +334,7 @@ class SeveralCheckedDateViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:several_checked_date'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -349,7 +350,7 @@ class CreditCheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:credit_checked_date_api'),
             {'year': 2001, 'month': 3, 'day': 10, 'pk': 2}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         d = CreditCheckedDate.objects.get(pk=2)
         self.assertEqual(d.name, 'AmexGold')
         self.assertEqual(d.date, date(2001, 3, 10))
@@ -366,7 +367,7 @@ class CreditCheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:credit_checked_date_api'),
             {'month': 3, 'day': 10, 'pk': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         d = CreditCheckedDate.objects.get(pk=2)
         self.assertEqual(d.name, 'AmexGold')
         self.assertEqual(d.date, date(2000, 2, 4))
@@ -383,7 +384,7 @@ class CreditCheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:credit_checked_date_api'),
             {'year': 2001, 'day': 10, 'pk': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         d = CreditCheckedDate.objects.get(pk=2)
         self.assertEqual(d.name, 'AmexGold')
         self.assertEqual(d.date, date(2000, 2, 4))
@@ -400,7 +401,7 @@ class CreditCheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:credit_checked_date_api'),
             {'year': 2001, 'month': 3, 'pk': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         d = CreditCheckedDate.objects.get(pk=2)
         self.assertEqual(d.name, 'AmexGold')
         self.assertEqual(d.date, date(2000, 2, 4))
@@ -417,7 +418,7 @@ class CreditCheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:credit_checked_date_api'),
             {'year': 2001, 'month': 3, 'day': 10}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         d = CreditCheckedDate.objects.get(pk=2)
         self.assertEqual(d.name, 'AmexGold')
         self.assertEqual(d.date, date(2000, 2, 4))
@@ -434,7 +435,7 @@ class CreditCheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:credit_checked_date_api'),
             {'year': 'a', 'month': 3, 'day': 10, 'pk': 2}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         d = CreditCheckedDate.objects.get(pk=2)
         self.assertEqual(d.name, 'AmexGold')
         self.assertEqual(d.date, date(2000, 2, 4))
@@ -446,7 +447,7 @@ class CreditCheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:credit_checked_date_api'),
             {'year': 2001, 'month': 3, 'day': 10, 'pk': 1000000}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_post_guest(self):
         d = CreditCheckedDate.objects.get(pk=2)
@@ -457,7 +458,7 @@ class CreditCheckedDateApiViewTestCase(BaseTestCase):
             reverse('moneybook:credit_checked_date_api'),
             {'year': 2001, 'month': 3, 'day': 10, 'pk': 2}
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         d = CreditCheckedDate.objects.get(pk=2)
         self.assertEqual(d.name, 'AmexGold')
         self.assertEqual(d.date, date(2000, 2, 4))
@@ -472,14 +473,14 @@ class LivingCostMarkApiViewTestCase(BaseTestCase):
             reverse('moneybook:living_cost_mark_api'),
             {'price': 2000}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(SeveralCosts.get_living_cost_mark(), 2000)
 
     def test_post_missing_price(self):
         self.client.force_login(User.objects.create_user(self.username))
         self.assertEqual(SeveralCosts.get_living_cost_mark(), 1000)
         response = self.client.post(reverse('moneybook:living_cost_mark_api'))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(SeveralCosts.get_living_cost_mark(), 1000)
 
     def test_post_str_price(self):
@@ -489,7 +490,7 @@ class LivingCostMarkApiViewTestCase(BaseTestCase):
             reverse('moneybook:living_cost_mark_api'),
             {'price': 'a'}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(SeveralCosts.get_living_cost_mark(), 1000)
 
     def test_post_guest(self):
@@ -498,7 +499,7 @@ class LivingCostMarkApiViewTestCase(BaseTestCase):
             reverse('moneybook:living_cost_mark_api'),
             {'price': 2000}
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(SeveralCosts.get_living_cost_mark(), 1000)
 
 
@@ -506,7 +507,7 @@ class UncheckedDataViewTestCase(BaseTestCase):
     def test_get(self):
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.get(reverse('moneybook:unchecked_data'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         expects = ['必需品1', 'スーパー', '計算外', '貯金', 'PayPayチャージ', '立替分1', '内部移動1', '内部移動2']
         self._assert_list(response.context['unchecked_data'], expects)
         self._assert_templates(
@@ -516,7 +517,7 @@ class UncheckedDataViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:unchecked_data'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))
 
 
@@ -531,7 +532,7 @@ class NowBankApiViewTestCase(BaseTestCase):
             reverse('moneybook:now_bank_api'),
             {'bank-1': 50000, 'bank-2': 10000, 'credit-1': 20000, 'credit-2': 3000}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(BankBalance.get_price(1), 50000)
         self.assertEqual(BankBalance.get_price(2), 10000)
         self.assertEqual(CreditCheckedDate.get_price(1), 20000)
@@ -549,7 +550,7 @@ class NowBankApiViewTestCase(BaseTestCase):
             reverse('moneybook:now_bank_api'),
             {'bank-1': 50000, 'credit-2': 3000}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(BankBalance.get_price(1), 50000)
         self.assertEqual(BankBalance.get_price(2), 20000)
         self.assertEqual(CreditCheckedDate.get_price(1), 30000)
@@ -564,7 +565,7 @@ class NowBankApiViewTestCase(BaseTestCase):
         self.assertEqual(CreditCheckedDate.get_price(2), 2000)
         self.client.force_login(User.objects.create_user(self.username))
         response = self.client.post(reverse('moneybook:now_bank_api'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         response_json = json.loads(response.content.decode())
         self.assertEqual(response_json['balance'], 54054 - (40000 + 20000 - 30000 - 2000))
         self.assertEqual(BankBalance.get_price(1), 40000)
@@ -582,7 +583,7 @@ class NowBankApiViewTestCase(BaseTestCase):
             reverse('moneybook:now_bank_api'),
             {'bank-1': 'a', 'bank-2': 10000, 'credit-1': 20000, 'credit-2': 3000}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(BankBalance.get_price(1), 40000)
         self.assertEqual(BankBalance.get_price(2), 20000)
         self.assertEqual(CreditCheckedDate.get_price(1), 30000)
@@ -598,7 +599,7 @@ class NowBankApiViewTestCase(BaseTestCase):
             reverse('moneybook:now_bank_api'),
             {'bank-1': 50000, 'bank-2': 10000, 'credit-1': 'a', 'credit-2': 3000}
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(BankBalance.get_price(1), 40000)
         self.assertEqual(BankBalance.get_price(2), 20000)
         self.assertEqual(CreditCheckedDate.get_price(1), 30000)
@@ -613,7 +614,7 @@ class NowBankApiViewTestCase(BaseTestCase):
             reverse('moneybook:now_bank_api'),
             {'bank-1': 50000, 'bank-2': 10000, 'credit-1': 20000, 'credit-2': 3000}
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(BankBalance.get_price(1), 40000)
         self.assertEqual(BankBalance.get_price(2), 20000)
         self.assertEqual(CreditCheckedDate.get_price(1), 30000)
@@ -631,7 +632,7 @@ class PreCheckedSummaryViewTestCase(BaseTestCase):
             data.save()
 
         response = self.client.get(reverse('moneybook:pre_checked_summary'))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context['income_sum'], 400)
         self.assertEqual(response.context['outgo_sum'], 3800)
         self.assertEqual(response.context['income_count'], 1)
@@ -643,5 +644,5 @@ class PreCheckedSummaryViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:pre_checked_summary'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(response.url, reverse('moneybook:login'))

--- a/moneybook/tests/views/tools_view_tests.py
+++ b/moneybook/tests/views/tools_view_tests.py
@@ -641,5 +641,4 @@ class PreCheckedSummaryViewTestCase(BaseTestCase):
 
     def test_get_guest(self):
         response = self.client.get(reverse('moneybook:pre_checked_summary'))
-        self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        self.assertEqual(response.url, reverse('moneybook:login'))
+        self.assertRedirects(response, reverse('moneybook:login'), status_code=HTTPStatus.FOUND)


### PR DESCRIPTION
HTTPステータスコードの使用方法を `http.HTTPStatus` に統一しました。

主な変更点:
1. `AGENTS.md` にコーディング規約を追記
   - ステータスコードには `http.HTTPStatus` を使用すること
   - インポート形式は `from http import HTTPStatus` とすること
   - 既存の Django `HttpResponse*` クラスの使用は許容すること
2. プロダクトコード（ビュー、ミドルウェア）の修正
   - 数値のリテラル（200, 400等）を `HTTPStatus.OK`, `HTTPStatus.BAD_REQUEST` 等に置き換え
3. テストコード（ユニットテスト、E2Eテスト）の修正
   - `self.assertEqual(response.status_code, 200)` 等を `HTTPStatus.OK` 等に置き換え
4. インポート順序の整理
   - `flake8-import-order` (smarketsスタイル) に準拠するよう、`from http import HTTPStatus` の位置を調整

ユニットテスト(271件)およびリントチェック(tox -e lint)を通過していることを確認済みです。

---
*PR created automatically by Jules for task [5548979565112043886](https://jules.google.com/task/5548979565112043886) started by @tMorriss*