### PR TITLE
ログアウトエラーの修正とE2Eテストの追加

### DIFF
--- a/moneybook/e2e/base.py
+++ b/moneybook/e2e/base.py
@@ -83,8 +83,8 @@ class PlaywrightBase(StaticLiveServerTestCase):
         self.page.fill('#id_password', self.password)
         # ログインボタンをクリック。遷移を待つ。
         self.page.click('input[value="ログイン"]')
-        # ログイン成功の証拠（ログアウトリンクの存在）を待つ。
-        self.page.wait_for_selector('a[href="' + reverse('moneybook:logout') + '"]')
+        # ログイン成功の証拠（ログアウトボタンの存在）を待つ。
+        self.page.wait_for_selector('button.link-button:has-text("ログアウト")')
 
     def _assert_common(self):
         # アプリ名

--- a/moneybook/e2e/login.py
+++ b/moneybook/e2e/login.py
@@ -5,8 +5,8 @@ from playwright.sync_api import expect
 
 class Login(PlaywrightBase):
     def _assert_login_success(self):
-        # ログイン成功の証拠（ログアウトリンクの存在）を待つ
-        self.page.wait_for_selector('a[href="' + reverse('moneybook:logout') + '"]')
+        # ログイン成功の証拠（ログアウトボタンの存在）を待つ
+        self.page.wait_for_selector('button.link-button:has-text("ログアウト")')
         # 名前表示
         expect(self.page.locator('.header-cont2')).to_contain_text(self.username + 'さん')
 
@@ -27,3 +27,9 @@ class Login(PlaywrightBase):
         self.page.fill('#id_password', self.password)
         self.page.press('#id_password', 'Enter')
         self._assert_login_success()
+
+    def test_logout(self):
+        self._login()
+        self.page.click('button.link-button:has-text("ログアウト")')
+        # ログアウト後はログイン画面に遷移することを確認
+        expect(self.page).to_have_url(self.live_server_url + reverse('moneybook:login'))

--- a/moneybook/e2e/login.py
+++ b/moneybook/e2e/login.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from django.urls import reverse
 from moneybook.e2e.base import PlaywrightBase
 from playwright.sync_api import expect
@@ -53,4 +55,4 @@ class Logout(PlaywrightBase):
 
         # CSRF検証エラー（403 Forbidden）が発生することを確認
         # Djangoのデフォルトの403ページが表示されるはず
-        expect(self.page.locator('body')).to_contain_text('403')
+        expect(self.page.locator('body')).to_contain_text(str(HTTPStatus.FORBIDDEN.value))

--- a/moneybook/e2e/login.py
+++ b/moneybook/e2e/login.py
@@ -40,13 +40,13 @@ class Logout(PlaywrightBase):
         self._login()
 
         # CSRFトークンを削除してPOSTリクエストを送信する
-        self.page.evaluate('''() => {
+        self.page.evaluate("""() => {
             const form = document.querySelector('form[action$="/logout"]');
             const csrfInput = form.querySelector('input[name="csrfmiddlewaretoken"]');
             if (csrfInput) {
                 csrfInput.remove();
             }
-        }''')
+        }""")
 
         # ログアウトボタンをクリック
         self.page.click('button.link-button:has-text("ログアウト")')

--- a/moneybook/e2e/login.py
+++ b/moneybook/e2e/login.py
@@ -28,8 +28,29 @@ class Login(PlaywrightBase):
         self.page.press('#id_password', 'Enter')
         self._assert_login_success()
 
+
+class Logout(PlaywrightBase):
     def test_logout(self):
         self._login()
         self.page.click('button.link-button:has-text("ログアウト")')
         # ログアウト後はログイン画面に遷移することを確認
         expect(self.page).to_have_url(self.live_server_url + reverse('moneybook:login'))
+
+    def test_logout_csrf_failure(self):
+        self._login()
+
+        # CSRFトークンを削除してPOSTリクエストを送信する
+        self.page.evaluate('''() => {
+            const form = document.querySelector('form[action$="/logout"]');
+            const csrfInput = form.querySelector('input[name="csrfmiddlewaretoken"]');
+            if (csrfInput) {
+                csrfInput.remove();
+            }
+        }''')
+
+        # ログアウトボタンをクリック
+        self.page.click('button.link-button:has-text("ログアウト")')
+
+        # CSRF検証エラー（403 Forbidden）が発生することを確認
+        # Djangoのデフォルトの403ページが表示されるはず
+        expect(self.page.locator('body')).to_contain_text('403')

--- a/moneybook/e2e/periodic.py
+++ b/moneybook/e2e/periodic.py
@@ -15,7 +15,7 @@ class Periodic(PlaywrightBase):
         self.page.fill('input[name^="day_new_0"]', str(day))
         self.page.fill('input[name^="item_new_0"]', item)
         self.page.fill('input[name^="price_new_0"]', str(price))
-        self.page.click('button[type="submit"]')
+        self.page.click('#periodic_edit_form button[type="submit"]')
         expect(self.page).to_have_url(self.live_server_url + reverse('moneybook:periodic'))
 
     def test_periodic_navigation_and_access(self):
@@ -73,7 +73,7 @@ class Periodic(PlaywrightBase):
         self.page.click('input[value="編集"]')
         # 編集対象の行を探して値を書き換え
         self.page.fill('input[name^="item_"]:not([name*="new"])', updated_item)
-        self.page.click('button[type="submit"]')
+        self.page.click('#periodic_edit_form button[type="submit"]')
 
         expect(self.page).to_have_url(self.live_server_url + reverse('moneybook:periodic'))
         expect(self.page.locator('#periodic_table')).to_contain_text(updated_item)
@@ -91,7 +91,7 @@ class Periodic(PlaywrightBase):
         self.page.click('button.btn-delete-row')
         # DOMから消えたことを確認
         expect(self.page.locator(f'input[value="{item_name}"]')).to_have_count(0)
-        self.page.click('button[type="submit"]')
+        self.page.click('#periodic_edit_form button[type="submit"]')
 
         expect(self.page).to_have_url(self.live_server_url + reverse('moneybook:periodic'))
         expect(self.page.locator('#periodic_table')).not_to_contain_text(item_name)

--- a/moneybook/static/style.css
+++ b/moneybook/static/style.css
@@ -239,6 +239,21 @@ section h2 {
     padding: 0 5px;
 }
 
+/* link-button */
+.link-button {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: #0000ee;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.link-button:hover {
+    text-decoration: underline;
+}
+
 /* 編集ボタン */
 .a-edit,
 .a-edit input[type="button"] {

--- a/moneybook/templates/_base.html
+++ b/moneybook/templates/_base.html
@@ -25,7 +25,12 @@
             <h1><a href="{% url 'moneybook:index' %}" class="logo">{{ app_name }}</a></h1>
         </div>
         <div class="header-cont2">
-            {{ username }}さん(<a href="{% url 'moneybook:logout' %}">ログアウト</a>)
+            {{ username }}さん(
+            <form action="{% url 'moneybook:logout' %}" method="post" style="display: inline;">
+                {% csrf_token %}
+                <button type="submit" class="link-button">ログアウト</button>
+            </form>
+            )
         </div>
     </header>
     <nav class="task_bar">


### PR DESCRIPTION
ログアウトがエラーになる問題を修正し、E2Eテストを追加しました。

### 変更内容
1.  **バックエンド/テンプレート**:
    - `moneybook/templates/_base.html` において、ログアウト処理をGETリクエストからCSRF保護されたPOSTリクエスト（フォーム形式）に変更しました。これはDjango 5.0以降（および使用中のDjango 6.x）でログアウトがPOST専用になったことに対応するためです。
2.  **スタイル**:
    - `moneybook/static/style.css` に `.link-button` クラスを追加し、フォームの送信ボタンを従来の「ログアウト」リンクと同じ見た目になるよう調整しました。
3.  **E2Eテスト**:
    - `moneybook/e2e/login.py` に `test_logout` テストメソッドを追加しました。ログイン後にヘッダーのログアウトボタンを押し、ログイン画面に正しく戻ることを検証します。
    - また、`moneybook/e2e/base.py` および `login.py` 内の既存のログイン処理において、ログアウト「リンク」ではなく「ボタン」の存在を待機するように修正しました。

### 検証結果
- `moneybook/e2e/login.py` の全テスト（4件）がパスすることを確認しました。
- 既存のビューのユニットテスト（145件）がすべてパスすることを確認しました。
- ローカル環境で実際にログイン・ログアウトが視覚的に正しく動作することをスクリーンショットにて確認済みです。

---
*PR created automatically by Jules for task [7575852324651922682](https://jules.google.com/task/7575852324651922682) started by @tMorriss*